### PR TITLE
Improve parsing error readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,7 @@
 - [FEATURE #16](https://github.com/MalteJanz/ludtwig/issues/16):
   Implemented support for twig comments and structures like `if` / `block` / ... in the attributes of an html tag.
   Tag attributes are only a subset of the AST structure and their children only can contain other Tag attributes (for example no html tag as an html attribute is possible).
-  
+- \[BUG\]: 
+  Improved readability for parsing errors by displaying the error and its context in a way that is readable by the user.
+  For example missing closing tags will give the context with each attribute to identify the right tag.
+  The attributes were not displayed in a user readable way before this change.

--- a/libs/twig/src/lib.rs
+++ b/libs/twig/src/lib.rs
@@ -82,7 +82,7 @@ mod tests {
 
         let pretty = result.pretty_helpful_error_string(input);
         //println!("{}", pretty);
-        assert_eq!(pretty, "Parsing goes wrong in line 6 and column 17 :\n                {% endblock %}\n                ^\n                |\nMissing closing tag for opening tag \'p\' with attributes [HtmlAttribute(HtmlAttribute { name: \"class\", value: Some(\"swag-migration-index-modal-abort-migration-confirm-dialog-hint\") })]");
+        assert_eq!(pretty, "Parsing goes wrong in line 6 and column 17 :\n                {% endblock %}\n                ^\n                |\nMissing closing tag for opening tag \'p\' with attributes [ class=\"swag-migration-index-modal-abort-migration-confirm-dialog-hint\" ]");
     }
 
     #[test]
@@ -112,7 +112,47 @@ mod tests {
 
         let pretty = result.pretty_helpful_error_string(input);
         //println!("{}", pretty);
-        assert_eq!(pretty, "Parsing goes wrong in line 7 and column 19 :\n                </div>\n                  ^\n                  |\nMissing closing tag for opening tag \'p\' with attributes [HtmlAttribute(HtmlAttribute { name: \"class\", value: Some(\"swag-migration-index-modal-abort-migration-confirm-dialog-hint\") })]");
+        assert_eq!(pretty, "Parsing goes wrong in line 7 and column 19 :\n                </div>\n                  ^\n                  |\nMissing closing tag for opening tag \'p\' with attributes [ class=\"swag-migration-index-modal-abort-migration-confirm-dialog-hint\" ]");
+    }
+
+    #[test]
+    fn test_missing_closing_tag_error_with_twig_if_in_attributes() {
+        let input = "{% block swag_migration_index_main_page_modal_abort_migration_confirmDialog_message_hint %}
+                <p class=\"swag-migration-index-modal-abort-migration-confirm-dialog-hint\" {# this is a comment #}
+                   {% if isHidden %}
+                       style=\"display: none;\"
+                   {% endif %}>
+                    Hello world
+                <div>
+                </div>
+                {% endblock %}";
+        let result = parse(input).unwrap_err();
+
+        let pretty = result.pretty_helpful_error_string(input);
+        //println!("{}", pretty);
+        assert_eq!(pretty, "Parsing goes wrong in line 9 and column 17 :\n                {% endblock %}\n                ^\n                |\nMissing closing tag for opening tag \'p\' with attributes [ class=\"swag-migration-index-modal-abort-migration-confirm-dialog-hint\" {# this is a comment #} {% if isHidden %} style=\"display: none;\" {% endif %} ]");
+    }
+
+    #[test]
+    fn test_missing_closing_tag_error_with_twig_if_elseif_else_in_attributes() {
+        let input = "{% block swag_migration_index_main_page_modal_abort_migration_confirmDialog_message_hint %}
+                <p class=\"swag-migration-index-modal-abort-migration-confirm-dialog-hint\" {# this is a comment #}
+                   {% if isHidden %}
+                       style=\"display: none;\"
+                   {% elseif isInline %}
+                       style=\"display: inline;\"
+                   {% else %}
+                       style=\"display: block;\"
+                   {% endif %}>
+                    Hello world
+                <div>
+                </div>
+                {% endblock %}";
+        let result = parse(input).unwrap_err();
+
+        let pretty = result.pretty_helpful_error_string(input);
+        //println!("{}", pretty);
+        assert_eq!(pretty, "Parsing goes wrong in line 13 and column 17 :\n                {% endblock %}\n                ^\n                |\nMissing closing tag for opening tag \'p\' with attributes [ class=\"swag-migration-index-modal-abort-migration-confirm-dialog-hint\" {# this is a comment #} {% if isHidden %} style=\"display: none;\" {% elseif isInline %} style=\"display: inline;\" {% else %} style=\"display: block;\" {% endif %} ]");
     }
 
     #[test]

--- a/libs/twig/src/parser/html.rs
+++ b/libs/twig/src/parser/html.rs
@@ -116,8 +116,11 @@ pub(crate) fn html_complete_tag(input: Input) -> IResult<SyntaxNode> {
         let (remaining_new, _close) = dynamic_context(
             || {
                 format!(
-                    "Missing closing tag for opening tag '{}' with attributes {:?}",
-                    open, attributes
+                    "Missing closing tag for opening tag '{}' with attributes [{} ]",
+                    open,
+                    attributes
+                        .iter()
+                        .fold(String::new(), |acc, att| format!("{} {}", acc, att))
                 )
             },
             cut(html_close_tag(open)),

--- a/libs/twig/src/parser/twig.rs
+++ b/libs/twig/src/parser/twig.rs
@@ -221,7 +221,12 @@ pub(crate) fn twig_apply_block<R, T: GenericChildParser<R>>(input: Input) -> IRe
     let (remaining, children) = T::generic_parse_children(remaining)?;
 
     let (remaining, _close) = dynamic_context(
-        || format!("Missing endapply for '{}' twig for expression", expression),
+        || {
+            format!(
+                "Missing endapply for '{}' twig apply expression",
+                expression
+            )
+        },
         cut(twig_closing_structure("endapply")),
     )(remaining)?;
 
@@ -305,9 +310,9 @@ pub(crate) fn twig_if_block<R, T: GenericChildParser<R>>(input: Input) -> IResul
                 let error_info = TwigParsingErrorInformation::add_dynamic_context(
                     remaining,
                     format!(
-                        "no 'endif' found for if block with expression '{:?}'",
+                        "no 'endif' found for if block with expression '{}'",
                         // it's safe to unwrap here, because arms contains at least one element
-                        arms.first().unwrap().expression
+                        arms.first().unwrap().expression.clone().unwrap_or_default()
                     ),
                     error_info,
                 );


### PR DESCRIPTION
This fixes mostly a bug (user facing output was formatted as debug information) and this was problematic because the TagAttribute data structure is now more complicated.