### PR TITLE
Optimization/try async std instead of tokio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # NEXT-VERSION
+- Performance increase of around 91% (almost doubled) in some cases
+- Improved directory traversal to skip hidden directories and files
 
 # v0.2.1
 - Bump version for crates.io release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+dependencies = [
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "libc",
+ "log",
+ "nb-connect",
+ "once_cell",
+ "parking",
+ "polling",
+ "vec-arena",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
+dependencies = [
+ "async-attributes",
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +148,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -62,16 +191,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytes"
-version = "1.0.0"
+name = "blocking"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+
+[[package]]
+name = "cc"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -106,10 +267,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bcb9d7dcbf7002aaffbb53eac22906b64cdcc127971dcc387d8eb7c95d5560"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
+name = "fastrand"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+
+[[package]]
+name = "futures-io"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+
+[[package]]
+name = "futures-lite"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "hashbrown"
@@ -146,6 +401,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,7 +441,7 @@ checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "ryu",
  "static_assertions",
 ]
@@ -171,14 +453,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if 1.0.0",
+ "value-bag",
+]
+
+[[package]]
 name = "ludtwig"
 version = "0.2.1"
 dependencies = [
  "ansi_term",
+ "async-std",
  "async-trait",
  "clap",
  "ludtwig-parser",
- "tokio",
  "walkdir",
 ]
 
@@ -196,6 +488,16 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "nb-connect"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "nom"
@@ -220,16 +522,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
 name = "os_str_bytes"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e36743d754ccdf9954c2e352ce2d4b106e024c814f6499c2dadff80da9a442d8"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "polling"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log",
+ "wepoll-sys",
+ "winapi",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -295,6 +628,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,31 +681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efab2086f17abcddb8f756117665c958feee6b2e39974c2f1600592ab3a4195"
-dependencies = [
- "autocfg",
- "bytes",
- "memchr",
- "num_cpus",
- "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +699,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "value-bag"
+version = "1.0.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
+dependencies = [
+ "ctor",
+]
+
+[[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +726,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +740,91 @@ dependencies = [
  "same-file",
  "winapi",
  "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+
+[[package]]
+name = "web-sys"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wepoll-sys"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ codegen-units = 1 # do not compile crates in parallel to allow for further optim
 [dependencies]
 ludtwig-parser = "0.2.1"
 clap = "~3.0.0-beta.2"
-async-std = { version = "1.9.0", features = ["attributes"] }
+async-std = { version = "~1.9.0", features = ["attributes"] }
 ansi_term = "~0.12.1"
 walkdir = "~2.3.1"
 async-trait = "0.1.42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ codegen-units = 1 # do not compile crates in parallel to allow for further optim
 [dependencies]
 ludtwig-parser = "0.2.1"
 clap = "~3.0.0-beta.2"
-tokio = { version = "~1.1.0", features = ["rt-multi-thread", "sync", "fs", "io-util", "macros"] }
+async-std = { version = "1.9.0", features = ["attributes"] }
 ansi_term = "~0.12.1"
 walkdir = "~2.3.1"
 async-trait = "0.1.42"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See the [LICENSE](./LICENSE) file for details.
 ### Dependencies / License notices*
 If you build this project locally or use the distributed binary keep also the following licenses in mind:
 - [ludtwig-parser](https://github.com/MalteJanz/ludtwig-parser) - [MIT](https://github.com/MalteJanz/ludtwig-parser/blob/main/LICENSE)
-- [tokio](https://github.com/tokio-rs/tokio) - [MIT](https://github.com/tokio-rs/tokio/blob/master/LICENSE)
+- [async-std](https://github.com/async-rs/async-std) - [MIT](https://github.com/async-rs/async-std/blob/master/LICENSE-MIT) / [Apache 2.0](https://github.com/async-rs/async-std/blob/master/LICENSE-APACHE)
 - [clap](https://github.com/clap-rs/clap) - [MIT](https://github.com/clap-rs/clap/blob/master/LICENSE-MIT) / [Apache 2.0](https://github.com/clap-rs/clap/blob/master/LICENSE-APACHE)
 - [ansi_term](https://github.com/ogham/rust-ansi-term) - [MIT](https://github.com/ogham/rust-ansi-term/blob/master/LICENCE)
 - [walkdir](https://github.com/BurntSushi/walkdir) - [MIT](https://github.com/BurntSushi/walkdir/blob/master/LICENSE-MIT) / [UNLICENSE](https://github.com/BurntSushi/walkdir/blob/master/UNLICENSE)

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1,29 +1,28 @@
 use crate::output::Output;
 use crate::process::FileContext;
+use async_std::future::Future;
+use async_std::sync::Arc;
+use async_std::task;
 use ludtwig_parser::ast::{SyntaxNode, TwigBlock, TwigStructure};
 use std::collections::HashSet;
-use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 
 /// Entry function for doing the analyzing.
 /// It spawns all analyzer functions concurrently.
 pub async fn analyze<'a>(file_context: Arc<FileContext>) {
     let clone = Arc::clone(&file_context);
 
-    tokio::spawn(async move {
+    task::spawn(async move {
         let mut block_names = HashSet::new();
         analyze_blocks(&file_context.tree, &clone, &mut block_names).await;
     })
-    .await
-    .unwrap();
+    .await;
 
     /*
-    tokio::spawn(async move {
+    task::spawn(async move {
         analyze_blocks(&file_context.tree, &clone, None).await;
     })
-    .await
-    .unwrap();
+    .await;
     */
 
     // run more analyzers in parallel...

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,13 @@ mod process;
 mod writer;
 
 use crate::output::OutputMessage;
+use async_std::channel::Sender;
+use async_std::fs;
+use async_std::path::PathBuf;
+use async_std::sync::Arc;
+use async_std::{channel, task};
 use clap::{crate_authors, crate_version, Clap, ValueHint};
 use std::boxed::Box;
-use std::path::PathBuf;
-use std::sync::Arc;
-use tokio::fs::{self};
-use tokio::sync::mpsc;
 use walkdir::WalkDir;
 
 /// A CLI tool for '.twig' files with focus on formatting and detecting mistakes.
@@ -36,7 +37,7 @@ struct Opts {
 #[derive(Debug)]
 pub struct CliContext {
     /// Channel sender for transmitting messages back to the user.
-    pub output_tx: mpsc::Sender<OutputMessage>,
+    pub output_tx: Sender<OutputMessage>,
     /// Disable the analysis of the syntax tree. There will still be parsing errors.
     pub no_analysis: bool,
     /// Disable the formatted writing of the syntax tree to disk. With this option the tool will not write to any files.
@@ -56,11 +57,7 @@ impl CliContext {
 fn main() {
     let opts: Opts = Opts::parse();
 
-    let runtime = tokio::runtime::Runtime::new().expect("can't create tokio runtime");
-
-    let process_code = runtime.block_on(app(opts)).unwrap();
-
-    drop(runtime);
+    let process_code = task::block_on(app(opts)).unwrap();
 
     std::process::exit(process_code);
 }
@@ -70,7 +67,7 @@ async fn app(opts: Opts) -> Result<i32, Box<dyn std::error::Error>> {
     println!("Parsing files...");
 
     // sender and receiver channels for the communication between tasks and the user.
-    let (tx, rx) = mpsc::channel(128);
+    let (tx, rx) = channel::bounded(128);
 
     let cli_context = Arc::new(CliContext {
         output_tx: tx,
@@ -79,20 +76,20 @@ async fn app(opts: Opts) -> Result<i32, Box<dyn std::error::Error>> {
         output_path: opts.output_path,
     });
 
-    let output_handler = tokio::spawn(output::handle_processing_output(rx));
+    let output_handler = task::spawn(output::handle_processing_output(rx));
 
     let mut futures = Vec::with_capacity(opts.files.len());
     for path in opts.files {
         let context = Arc::clone(&cli_context);
-        futures.push(tokio::task::spawn(handle_input_path(path, context)));
+        futures.push(task::spawn(handle_input_path(path, context)));
     }
     drop(cli_context);
 
     for t in futures {
-        t.await.unwrap();
+        t.await;
     }
 
-    let process_code = output_handler.await.unwrap();
+    let process_code = output_handler.await;
 
     Ok(process_code)
 }
@@ -115,7 +112,7 @@ async fn handle_input_path(path: PathBuf, cli_context: Arc<CliContext>) {
 
 /// Process a directory path.
 async fn handle_input_dir(path: PathBuf, cli_context: Arc<CliContext>) {
-    let processes = tokio::task::spawn_blocking(move || {
+    let processes = task::spawn(async move {
         let mut futures_processes = Vec::new();
 
         for entry in WalkDir::new(path) {
@@ -128,7 +125,7 @@ async fn handle_input_dir(path: PathBuf, cli_context: Arc<CliContext>) {
 
             if let Some(file_type) = path.extension() {
                 if file_type == "twig" {
-                    futures_processes.push(tokio::spawn(process::process_file(
+                    futures_processes.push(task::spawn(process::process_file(
                         path.into(),
                         Arc::clone(&cli_context),
                     )));
@@ -138,10 +135,9 @@ async fn handle_input_dir(path: PathBuf, cli_context: Arc<CliContext>) {
 
         futures_processes
     })
-    .await
-    .unwrap();
+    .await;
 
     for f in processes {
-        f.await.unwrap();
+        f.await;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use async_std::sync::Arc;
 use async_std::{channel, task};
 use clap::{crate_authors, crate_version, Clap, ValueHint};
 use std::boxed::Box;
-use walkdir::WalkDir;
+use walkdir::{DirEntry, WalkDir};
 
 /// A CLI tool for '.twig' files with focus on formatting and detecting mistakes.
 #[derive(Clap, Debug, Clone)]
@@ -110,27 +110,47 @@ async fn handle_input_path(path: PathBuf, cli_context: Arc<CliContext>) {
     handle_input_dir(path, cli_context).await;
 }
 
+/// filters out hidden directories or files
+/// (that start with '.').
+fn is_hidden(entry: &DirEntry) -> bool {
+    !entry
+        .file_name()
+        .to_str()
+        .map(|s| s.starts_with('.'))
+        .unwrap_or(false)
+}
+
 /// Process a directory path.
 async fn handle_input_dir(path: PathBuf, cli_context: Arc<CliContext>) {
     let processes = task::spawn(async move {
         let mut futures_processes = Vec::new();
+        let walker = WalkDir::new(path).into_iter();
 
-        for entry in WalkDir::new(path) {
+        for entry in walker.filter_entry(|e| is_hidden(e)) {
             let entry = entry.unwrap();
-            let path = entry.path();
 
-            if !path.is_file() {
+            if !entry.file_type().is_file() {
                 continue;
             }
 
-            if let Some(file_type) = path.extension() {
-                if file_type == "twig" {
-                    futures_processes.push(task::spawn(process::process_file(
-                        path.into(),
-                        Arc::clone(&cli_context),
-                    )));
-                }
+            if !entry
+                .file_name()
+                .to_str() // also skips non utf-8 file names!
+                .map(|s| s.ends_with(".twig"))
+                .unwrap_or(false)
+            {
+                continue;
             }
+
+            let path = entry.path();
+            futures_processes.push(task::spawn(process::process_file(
+                path.into(),
+                Arc::clone(&cli_context),
+            )));
+
+            // cooperatively give up computation time in this thread to allow other futures to process.
+            // because WalkDir is not async this is in fact helpful for the overall performance.
+            task::yield_now().await;
         }
 
         futures_processes

--- a/src/output.rs
+++ b/src/output.rs
@@ -53,7 +53,7 @@ pub async fn handle_processing_output(rx: Receiver<OutputMessage>) -> i32 {
             continue;
         }
 
-        println!("\nFile: {:?}", file_path);
+        println!("\nFile: {:?}", file_path.as_os_str());
 
         for output in output_list {
             match output {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,9 +1,9 @@
 use ansi_term::Colour::*;
 use ansi_term::Style;
+use async_std::channel::Receiver;
+use async_std::path::PathBuf;
+use async_std::sync::Arc;
 use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::Arc;
-use tokio::sync::mpsc;
 
 /// The user output has different variants.
 #[derive(Debug, Clone, PartialEq)]
@@ -25,13 +25,13 @@ pub struct OutputMessage {
 
 /// This function receives all the [OutputMessage] instances from the receiver channel and
 /// prints information to the console / user.
-pub async fn handle_processing_output(mut rx: mpsc::Receiver<OutputMessage>) -> i32 {
+pub async fn handle_processing_output(rx: Receiver<OutputMessage>) -> i32 {
     let mut map = HashMap::new();
     let mut file_count = 0;
     let mut warning_count = 0;
     let mut error_count = 0;
 
-    while let Some(msg) = rx.recv().await {
+    while let Ok(msg) = rx.recv().await {
         let entry = map.entry(msg.file).or_insert_with(Vec::new);
 
         match msg.output {


### PR DESCRIPTION
The experimental switch to the async-std runtime was giving a suprising performance speedup: ~35% on it's own.

After improving the directory traversal (which was blocking code) with some calls for yielding processing time back to the runtime it increased the performance even more. It also skips hidden files and directories now.

***After all this branch gives an performance improvement of around 91%*** (almost double the performance) on my machine for my largest testcase.