### PR TITLE
Fix twig block nesting whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # NEXT-VERSION
-
+- [Bugfix #27](https://github.com/MalteJanz/ludtwig/issues/27):
+  Twig block nesting was causing missing empty lines around twig blocks in some cases.
 
 # v0.4.0
 - An Update of [ludtwig-parser (see changelog)](https://github.com/MalteJanz/ludtwig-parser/releases/tag/v0.3.0)


### PR DESCRIPTION
closes #27 

This PR changes the formatting under certain conditions for twig blocks.

Input template:
```twig
{% block swag_amazon_pay_configuration_card_account %}
    {% block swag_amazon_pay_configuration_card_account_content %}
        {% block swag_amazon_pay_configuration_card_account_content_configuration_text %}

            <div class="swag-amazon-pay-configuration-text">
                <span class="headline headline-m">{{ $tc('swag-amazon-pay-configuration.configForm.registerHeadline') }}</span>
                <span v-html="$tc('swag-amazon-pay-configuration.configForm.registerExplanation')"></span>
            </div>
            <div class="swag-amazon-pay-configuration-text">
                <span class="headline headline-m">{{ $tc('swag-amazon-pay-configuration.configForm.existingAccountHeadline') }}</span>
                <span v-html="$tc('swag-amazon-pay-configuration.configForm.existingAccountExplanation')"></span>
            </div>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_headline_account_information %}
            <div class="swag-amazon-pay-configuration-text add-margin-top">
                            <span class="headline headline-s">
                                {{ $tc('swag-amazon-pay-configuration.configForm.accountHeadline') }}
                            </span>
            </div>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_option_ledger_currency %}
            <div class="sw-field--margin-top">
                <sw-single-select
                        v-model="config.ledgerCurrency"
                        required
                        :options="getLedgerCurrencyOptions"
                        :label="$tc('swag-amazon-pay-configuration.configForm.fields.ledgerCurrency.label')"
                        :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.ledgerCurrency.placeholder')"
                        :disabled="isInherited">
                </sw-single-select>
            </div>
        {% endblock %}

        <div class="swag-amazon-pay-configuration-columns">
            <div class="column">

                {% block swag_amazon_pay_configuration_card_account_content_option_merchant_id %}
                    <sw-text-field
                            v-model="config.merchantId"
                            required
                            :label="$tc('swag-amazon-pay-configuration.configForm.fields.merchantId.label')"
                            :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.merchantId.placeholder')"
                            :disabled="isInherited">
                    </sw-text-field>
                {% endblock %}

            </div>
            <div class="column"></div>
            <div class="column">

                {% block swag_amazon_pay_configuration_card_account_content_option_client_id %}
                    <sw-text-field
                            v-model="config.clientId"
                            required
                            :label="$tc('swag-amazon-pay-configuration.configForm.fields.clientId.label')"
                            :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.clientId.placeholder')"
                            :disabled="isInherited">
                    </sw-text-field>
                {% endblock %}

            </div>
        </div>

        {% block swag_amazon_pay_configuration_card_account_content_headline_credentials %}
            <div class="swag-amazon-pay-configuration-text add-margin-top">
                            <span class="headline headline-s">
                                {{ $tc('swag-amazon-pay-configuration.configForm.credentialsHeadline') }}
                            </span>
            </div>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_option_public_key_id %}
            <sw-text-field
                    v-model="config.publicKeyId"
                    required
                    :label="$tc('swag-amazon-pay-configuration.configForm.fields.publicKeyId.label')"
                    :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.publicKeyId.placeholder')"
                    :disabled="isInherited">
            </sw-text-field>
        {% endblock %}

        {% block swag_amazon_pay_settings_card_account_private_key_modal %}
            <swag-amazon-pay-configuration-input-key-modal
                    v-if="showInputKeyModal"
                    @update-private-key="onUpdatePrivateKey"
                    @modal-close="onCloseModal()">
            </swag-amazon-pay-configuration-input-key-modal>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_field_private_key %}
            <sw-password-field
                    :placeholder="getPrivateKeyPlaceholder()"
                    :label="$tc('swag-amazon-pay-configuration.configForm.fields.privateKey.label')"
                    required
                    disabled
                    :passwordToggleAble="false">
            </sw-password-field>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_button_input_private_key %}
            <sw-button
                    variant="primary"
                    :disabled="isInherited"
                    @click="displayInputKeyModal">
                {{ $tc('swag-amazon-pay-configuration.actions.insertPrivateKey') }}
            </sw-button>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_config_test %}
            <sw-button-process
                    v-if="!showLoader"
                    class="sw-settings-login-registration__test-action"
                    :isLoading="showLoader"
                    :processSuccess="isTestSuccessful"
                    :disabled="showLoader || isTesting || isInherited"
                    @click="onTest">
                {{ $tc('swag-amazon-pay-configuration.actions.testConnection') }}
            </sw-button-process>
        {% endblock %}
    {% endblock %}
{% endblock %}
```

Output on main branch (which is missing empty lines around most of the twig blocks):
```twig
{% block swag_amazon_pay_configuration_card_account %}
    {% block swag_amazon_pay_configuration_card_account_content %}
        {% block swag_amazon_pay_configuration_card_account_content_configuration_text %}
            <div class="swag-amazon-pay-configuration-text">
                <span class="headline headline-m">{{ $tc('swag-amazon-pay-configuration.configForm.registerHeadline') }}</span>
                <span v-html="$tc('swag-amazon-pay-configuration.configForm.registerExplanation')"></span>
            </div>
            <div class="swag-amazon-pay-configuration-text">
                <span class="headline headline-m">{{ $tc('swag-amazon-pay-configuration.configForm.existingAccountHeadline') }}</span>
                <span v-html="$tc('swag-amazon-pay-configuration.configForm.existingAccountExplanation')"></span>
            </div>
        {% endblock %}
        {% block swag_amazon_pay_configuration_card_account_content_headline_account_information %}
            <div class="swag-amazon-pay-configuration-text add-margin-top">
                <span class="headline headline-s">
                    {{ $tc('swag-amazon-pay-configuration.configForm.accountHeadline') }}
                </span>
            </div>
        {% endblock %}
        {% block swag_amazon_pay_configuration_card_account_content_option_ledger_currency %}
            <div class="sw-field--margin-top">
                <sw-single-select
                        v-model="config.ledgerCurrency"
                        required
                        :options="getLedgerCurrencyOptions"
                        :label="$tc('swag-amazon-pay-configuration.configForm.fields.ledgerCurrency.label')"
                        :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.ledgerCurrency.placeholder')"
                        :disabled="isInherited">
                </sw-single-select>
            </div>
        {% endblock %}
        <div class="swag-amazon-pay-configuration-columns">
            <div class="column">

                {% block swag_amazon_pay_configuration_card_account_content_option_merchant_id %}
                    <sw-text-field
                            v-model="config.merchantId"
                            required
                            :label="$tc('swag-amazon-pay-configuration.configForm.fields.merchantId.label')"
                            :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.merchantId.placeholder')"
                            :disabled="isInherited">
                    </sw-text-field>
                {% endblock %}

            </div>
            <div class="column"></div>
            <div class="column">

                {% block swag_amazon_pay_configuration_card_account_content_option_client_id %}
                    <sw-text-field
                            v-model="config.clientId"
                            required
                            :label="$tc('swag-amazon-pay-configuration.configForm.fields.clientId.label')"
                            :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.clientId.placeholder')"
                            :disabled="isInherited">
                    </sw-text-field>
                {% endblock %}

            </div>
        </div>
        {% block swag_amazon_pay_configuration_card_account_content_headline_credentials %}
            <div class="swag-amazon-pay-configuration-text add-margin-top">
                <span class="headline headline-s">
                    {{ $tc('swag-amazon-pay-configuration.configForm.credentialsHeadline') }}
                </span>
            </div>
        {% endblock %}
        {% block swag_amazon_pay_configuration_card_account_content_option_public_key_id %}
            <sw-text-field
                    v-model="config.publicKeyId"
                    required
                    :label="$tc('swag-amazon-pay-configuration.configForm.fields.publicKeyId.label')"
                    :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.publicKeyId.placeholder')"
                    :disabled="isInherited">
            </sw-text-field>
        {% endblock %}
        {% block swag_amazon_pay_settings_card_account_private_key_modal %}
            <swag-amazon-pay-configuration-input-key-modal
                    v-if="showInputKeyModal"
                    @update-private-key="onUpdatePrivateKey"
                    @modal-close="onCloseModal()">
            </swag-amazon-pay-configuration-input-key-modal>
        {% endblock %}
        {% block swag_amazon_pay_configuration_card_account_content_field_private_key %}
            <sw-password-field
                    :placeholder="getPrivateKeyPlaceholder()"
                    :label="$tc('swag-amazon-pay-configuration.configForm.fields.privateKey.label')"
                    required
                    disabled
                    :passwordToggleAble="false">
            </sw-password-field>
        {% endblock %}
        {% block swag_amazon_pay_configuration_card_account_content_button_input_private_key %}
            <sw-button
                    variant="primary"
                    :disabled="isInherited"
                    @click="displayInputKeyModal">
                {{ $tc('swag-amazon-pay-configuration.actions.insertPrivateKey') }}
            </sw-button>
        {% endblock %}
        {% block swag_amazon_pay_configuration_card_account_content_config_test %}
            <sw-button-process
                    v-if="!showLoader"
                    class="sw-settings-login-registration__test-action"
                    :isLoading="showLoader"
                    :processSuccess="isTestSuccessful"
                    :disabled="showLoader || isTesting || isInherited"
                    @click="onTest">
                {{ $tc('swag-amazon-pay-configuration.actions.testConnection') }}
            </sw-button-process>
        {% endblock %}
    {% endblock %}
{% endblock %}
```

Output with this PR (which only skips empty lines around twig blocks when there is only one nested block inside it):
```twig
{% block swag_amazon_pay_configuration_card_account %}
    {% block swag_amazon_pay_configuration_card_account_content %}

        {% block swag_amazon_pay_configuration_card_account_content_configuration_text %}
            <div class="swag-amazon-pay-configuration-text">
                <span class="headline headline-m">{{ $tc('swag-amazon-pay-configuration.configForm.registerHeadline') }}</span>
                <span v-html="$tc('swag-amazon-pay-configuration.configForm.registerExplanation')"></span>
            </div>
            <div class="swag-amazon-pay-configuration-text">
                <span class="headline headline-m">{{ $tc('swag-amazon-pay-configuration.configForm.existingAccountHeadline') }}</span>
                <span v-html="$tc('swag-amazon-pay-configuration.configForm.existingAccountExplanation')"></span>
            </div>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_headline_account_information %}
            <div class="swag-amazon-pay-configuration-text add-margin-top">
                <span class="headline headline-s">
                    {{ $tc('swag-amazon-pay-configuration.configForm.accountHeadline') }}
                </span>
            </div>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_option_ledger_currency %}
            <div class="sw-field--margin-top">
                <sw-single-select
                        v-model="config.ledgerCurrency"
                        required
                        :options="getLedgerCurrencyOptions"
                        :label="$tc('swag-amazon-pay-configuration.configForm.fields.ledgerCurrency.label')"
                        :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.ledgerCurrency.placeholder')"
                        :disabled="isInherited">
                </sw-single-select>
            </div>
        {% endblock %}

        <div class="swag-amazon-pay-configuration-columns">
            <div class="column">

                {% block swag_amazon_pay_configuration_card_account_content_option_merchant_id %}
                    <sw-text-field
                            v-model="config.merchantId"
                            required
                            :label="$tc('swag-amazon-pay-configuration.configForm.fields.merchantId.label')"
                            :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.merchantId.placeholder')"
                            :disabled="isInherited">
                    </sw-text-field>
                {% endblock %}

            </div>
            <div class="column"></div>
            <div class="column">

                {% block swag_amazon_pay_configuration_card_account_content_option_client_id %}
                    <sw-text-field
                            v-model="config.clientId"
                            required
                            :label="$tc('swag-amazon-pay-configuration.configForm.fields.clientId.label')"
                            :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.clientId.placeholder')"
                            :disabled="isInherited">
                    </sw-text-field>
                {% endblock %}

            </div>
        </div>

        {% block swag_amazon_pay_configuration_card_account_content_headline_credentials %}
            <div class="swag-amazon-pay-configuration-text add-margin-top">
                <span class="headline headline-s">
                    {{ $tc('swag-amazon-pay-configuration.configForm.credentialsHeadline') }}
                </span>
            </div>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_option_public_key_id %}
            <sw-text-field
                    v-model="config.publicKeyId"
                    required
                    :label="$tc('swag-amazon-pay-configuration.configForm.fields.publicKeyId.label')"
                    :placeholder="$tc('swag-amazon-pay-configuration.configForm.fields.publicKeyId.placeholder')"
                    :disabled="isInherited">
            </sw-text-field>
        {% endblock %}

        {% block swag_amazon_pay_settings_card_account_private_key_modal %}
            <swag-amazon-pay-configuration-input-key-modal
                    v-if="showInputKeyModal"
                    @update-private-key="onUpdatePrivateKey"
                    @modal-close="onCloseModal()">
            </swag-amazon-pay-configuration-input-key-modal>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_field_private_key %}
            <sw-password-field
                    :placeholder="getPrivateKeyPlaceholder()"
                    :label="$tc('swag-amazon-pay-configuration.configForm.fields.privateKey.label')"
                    required
                    disabled
                    :passwordToggleAble="false">
            </sw-password-field>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_button_input_private_key %}
            <sw-button
                    variant="primary"
                    :disabled="isInherited"
                    @click="displayInputKeyModal">
                {{ $tc('swag-amazon-pay-configuration.actions.insertPrivateKey') }}
            </sw-button>
        {% endblock %}

        {% block swag_amazon_pay_configuration_card_account_content_config_test %}
            <sw-button-process
                    v-if="!showLoader"
                    class="sw-settings-login-registration__test-action"
                    :isLoading="showLoader"
                    :processSuccess="isTestSuccessful"
                    :disabled="showLoader || isTesting || isInherited"
                    @click="onTest">
                {{ $tc('swag-amazon-pay-configuration.actions.testConnection') }}
            </sw-button-process>
        {% endblock %}

    {% endblock %}
{% endblock %}
```

You may notice the non existing empty line around the first nested block. This is because ludtwig tries to save empty lines in cases like these:
```twig
{% block a %}
    {% block b %}
        {% block c %}
            {# deprecated ... #}
        {% endblock %}
    {% endblock %}
{% endblock %}
```