### PR TITLE
30 - Fix formatted line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # NEXT-VERSION
 - [Bugfix #29](https://github.com/MalteJanz/ludtwig/issues/29):
   Allow `.` or `./` (current working directory paths) as input
+- [Bugfix #30](https://github.com/MalteJanz/ludtwig/issues/30):
+  Fix ludtwig formatted files line endings to use CRLF on windows and LF on linux and macOS
 
 # v0.5.0
 - [Bugfix / Breaking change #27](https://github.com/MalteJanz/ludtwig/issues/27):


### PR DESCRIPTION
closes #30 

This PR does not fully fix the issue. The error reporting line number is still wrong on windows (and needs a fix in the parser crate).