### PR TITLE
Add docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+/target
+**/target
+.idea
+**/.idea
+.vscode
+**/.vscode
+/output
+/fixtures
+.github
+fuzz/corpus
+fuzz/artifacts
+/demo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# BUILDING ENVIRONMENT
+FROM nwtgck/rust-musl-builder:latest AS builder
+
+# Add source code.
+ADD --chown=rust:rust . ./
+
+# Build application.
+RUN cargo build --release
+
+# RUN ENVIRONMENT / FINAL IMAGE
+FROM alpine:latest
+
+COPY --from=builder \
+    /home/rust/src/target/x86_64-unknown-linux-musl/release/ludtwig \
+    /usr/local/bin/
+
+CMD ["/bin/sh"]
+# the system files should be mounted to the ludtwig directory to allow ludtwig to see them
+WORKDIR /ludtwig
+
+CMD ["ludtwig"]
+# this will auto execute ludtwig and only parameters are passed as arguments to docker run
+#ENTRYPOINT [ "/usr/local/bin/ludtwig" ]


### PR DESCRIPTION
This is still WIP because the ergonomics of the image are not final (the way you can use it). Also it still needs to be added into the release pipeline.

Current method of using the image is:
`docker run --rm -v $(pwd):/ludtwig maltejanz/ludtwig:0.5.1-beta ludtwig -W ./fixtures/migration`

closes #34 