### PR TITLE
55 - Fix twig accessor parser to allow dot operator array indexing

### DIFF
--- a/crates/ludtwig-parser/CHANGELOG.md
+++ b/crates/ludtwig-parser/CHANGELOG.md
@@ -1,5 +1,6 @@
 # NEXT-VERSION
 - Fix HTML Tag name parser token collisions, which caused tags like `source` to not parse correctly
+- Fix Twig accessor parser to allow array indexing by dot operator
 
 # v0.4.0
 - Rewrite of the whole parser to make it lossless and implemented error recovery


### PR DESCRIPTION
closes #55 