### PR TITLE
49+54 - Fix colon word syntax …

### DIFF
--- a/crates/ludtwig-parser/CHANGELOG.md
+++ b/crates/ludtwig-parser/CHANGELOG.md
@@ -1,6 +1,7 @@
 # NEXT-VERSION
 - Fix HTML Tag name parser token collisions, which caused tags like `source` to not parse correctly
 - Fix Twig accessor parser to allow array indexing by dot operator
+- Fix lexer and parsing of colon word syntax like `:special-attribute` as HTML attribute and now support `array[:upper]` as Twig slice
 
 # v0.4.0
 - Rewrite of the whole parser to make it lossless and implemented error recovery

--- a/crates/ludtwig-parser/src/lexer.rs
+++ b/crates/ludtwig-parser/src/lexer.rs
@@ -323,7 +323,6 @@ mod tests {
         check_regex("camelCase", T![word], "word");
         check_regex("kebab-case", T![word], "word");
         check_regex("snake_case", T![word], "word");
-        check_regex(":hello123", T![word], "word");
         check_regex("#hello123", T![word], "word");
         check_regex("@hello123", T![word], "word");
         check_regex("block1", T![word], "word");

--- a/crates/ludtwig-parser/src/parser/event.rs
+++ b/crates/ludtwig-parser/src/parser/event.rs
@@ -10,6 +10,11 @@ pub(super) enum Event {
     AddToken {
         kind: SyntaxKind,
     },
+    /// Combines the next n lexer tokens into one (in the tree) with a specified SyntaxKind
+    AddNextNTokensAs {
+        n: usize,
+        kind: SyntaxKind,
+    },
     FinishNode,
     /// Should consume any amount of trivia at this exact point in the tree
     ExplicitlyConsumeTrivia,
@@ -35,6 +40,10 @@ impl EventCollection {
 
     pub(super) fn add_token(&mut self, kind: SyntaxKind) {
         self.events.push(Event::AddToken { kind });
+    }
+
+    pub(super) fn add_next_n_tokens_as(&mut self, n: usize, kind: SyntaxKind) {
+        self.events.push(Event::AddNextNTokensAs { n, kind });
     }
 
     pub(super) fn explicitly_consume_trivia(&mut self) {

--- a/crates/ludtwig-parser/src/parser/source.rs
+++ b/crates/ludtwig-parser/src/parser/source.rs
@@ -24,6 +24,15 @@ impl<'source> Source<'source> {
         Some(token)
     }
 
+    pub(super) fn next_n_tokens(&mut self, n: usize) -> Vec<&'source Token<'source>> {
+        self.eat_trivia();
+
+        let token = self.tokens[self.cursor..].iter().take(n).collect();
+        self.cursor += n;
+
+        token
+    }
+
     pub(super) fn peek_kind(&mut self) -> Option<SyntaxKind> {
         self.eat_trivia();
         self.peek_kind_raw()
@@ -32,6 +41,14 @@ impl<'source> Source<'source> {
     pub(super) fn peek_token(&mut self) -> Option<&Token> {
         self.eat_trivia();
         self.peek_token_raw()
+    }
+
+    /// Lookahead is expensive!
+    /// This lookahead doesn't skip further trivia tokens and is only there for combining the next n lexer tokens!
+    /// for n of zero use `peek_token` instead!
+    pub(super) fn peek_nth_token(&mut self, n: usize) -> Option<&Token> {
+        self.eat_trivia();
+        self.tokens[self.cursor..].get(n)
     }
 
     pub(super) fn at_following(&mut self, set: &[SyntaxKind]) -> bool {

--- a/crates/ludtwig-parser/src/syntax/untyped.rs
+++ b/crates/ludtwig-parser/src/syntax/untyped.rs
@@ -30,7 +30,7 @@ pub enum SyntaxKind {
     TK_LINE_BREAK,
     /// a single word containing only characters, numbers or symbols
     /// must start with a alpha or one of the special starting characters followed by a normal alpha
-    #[regex(r"([a-zA-Z]|([:@\#_\$][a-zA-Z]))[a-zA-Z0-9_\-]*")]
+    #[regex(r"([a-zA-Z]|([@\#_\$][a-zA-Z]))[a-zA-Z0-9_\-]*")]
     TK_WORD,
     /// a valid twig number
     #[regex(r"[0-9]+(\.[0-9]+)?([Ee][\+\-][0-9]+)?")]


### PR DESCRIPTION
…to support missing whitespaces between colons and words in twig

closes #49 
closes #54 