### PR TITLE
Added parser documentation and more AST implementations

### DIFF
--- a/crates/ludtwig-parser/CHANGELOG.md
+++ b/crates/ludtwig-parser/CHANGELOG.md
@@ -1,6 +1,8 @@
 # NEXT-VERSION
 
 - [#50](https://github.com/MalteJanz/ludtwig/pull/50) Expose `Preorder` type for AST traversal
+- [#109](https://github.com/MalteJanz/ludtwig/pull/109) Added parser documentation and some more AST utility method
+  implementations
 
 # v0.5.3
 

--- a/crates/ludtwig-parser/src/lib.rs
+++ b/crates/ludtwig-parser/src/lib.rs
@@ -1,5 +1,109 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::doc_markdown)]
+//! # Parser
+//! This is a handwritten top-down parser for the [twig templating language](https://twig.symfony.com/) combined with HTML.
+//! It's mostly developed together with the linter / formatter [ludtwig](https://github.com/MalteJanz/ludtwig).
+//!
+//! Parsing both Twig and HTML together into a single hierarchical syntax tree gives some benefits,
+//! valid syntax trees follow some desirable properties:
+//! - non-self-closing HTML tags always need a corresponding closing tag
+//! - opening and closing HTML tag must exist inside the same Twig block
+//! - Twig syntax is only allowed in specific places instead of everywhere
+//!
+//! which in turn make these templates and the HTML generated in the end less error-prone.
+//!
+//! # Syntax trees
+//! The parser constructs a syntax tree based on the library [rowan](https://github.com/rust-analyzer/rowan).
+//! A conceptual overview can be found here [Syntax in rust-analyzer](https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/syntax.md).
+//! Basically the syntax tree consists of three layers:
+//! - GreenNodes
+//! - SyntaxNodes (aka RedNodes)
+//! - AstNodes (defined in this crate)
+//!
+//! # Examples
+//!
+//! ## Parsing into a syntax tree
+//! ```
+//! use ludtwig_parser::syntax::untyped::{debug_tree, SyntaxNode};
+//!
+//! let parse = ludtwig_parser::parse("{{ 42 }}");
+//!
+//! // parsing might result in errors
+//! assert!(parse.errors.is_empty());
+//!
+//! // in any case it will always produce a usable syntax tree
+//! // and provide a green node of the root.
+//!
+//! // for getting a SyntaxNode of the root you can use this shortcut
+//! // or construct the root by hand from the GreenNode (see SyntaxNode::new_root)
+//! let (tree_root, errors) = parse.split();
+//!
+//! // you can now iterate or search through the syntax tree
+//! // or debug print it with
+//! println!("{}", debug_tree(&tree_root));
+//! # assert_eq!(debug_tree(&tree_root), r##"ROOT@0..8
+//! #   TWIG_VAR@0..8
+//! #     TK_OPEN_CURLY_CURLY@0..2 "{{"
+//! #     TWIG_EXPRESSION@2..5
+//! #       TWIG_LITERAL_NUMBER@2..5
+//! #         TK_WHITESPACE@2..3 " "
+//! #         TK_NUMBER@3..5 "42"
+//! #     TK_WHITESPACE@5..6 " "
+//! #     TK_CLOSE_CURLY_CURLY@6..8 "}}""##);
+//! ```
+//!
+//! ## Iterate in Preorder
+//! ```
+//! # let parse = ludtwig_parser::parse("{{ 42 }}");
+//! # let (tree_root, errors) = parse.split();
+//!
+//! use ludtwig_parser::syntax::untyped::WalkEvent;
+//! use ludtwig_parser::syntax::typed::AstNode;
+//! use ludtwig_parser::syntax::typed::TwigVar;
+//!
+//! let mut preorder = tree_root.preorder();
+//! while let Some(walk_event) = preorder.next() {
+//!     match walk_event {
+//!        WalkEvent::Enter(syntax_node) => {
+//!            if let Some(twig_var) = TwigVar::cast(syntax_node) {
+//!                // do something with ast node here
+//!            }
+//!        }
+//!        WalkEvent::Leave(syntax_node) => {}
+//!     }
+//! }
+//! ```
+//!
+//! ## Utilities for retrieving a specific AstNode or Token
+//! As of now there might be missing utility method implementations on AstNode's.
+//! You can use these instead to retrieve any AstNode / Token you want (under a given AstNode).
+//! ```
+//! # let parse = ludtwig_parser::parse("{{ 42 }}");
+//! # let (tree_root, errors) = parse.split();
+//!
+//! use ludtwig_parser::syntax::typed::{AstNode, support, TwigVar};
+//! use ludtwig_parser::syntax::untyped::SyntaxToken;
+//! use ludtwig_parser::T;
+//!
+//! // finding a specific AstNode in a (sub) tree (first occurrence)
+//! // Note: only looks through the direct children of the given SyntaxNode
+//! let twig_var: TwigVar = support::child(&tree_root).unwrap();
+//!
+//! // you can freely get the underlaying SyntaxNode of an AstNode with
+//! let twig_var_syntax_node = twig_var.syntax();
+//!
+//! // finding a specific Token in a (sub) tree (first occurrence)
+//! // Note: only looks through the direct children of the given SyntaxNode
+//! let twig_var_opening_braces: SyntaxToken = support::token(twig_var_syntax_node, T!["{{"]).unwrap();
+//!
+//! // finding specific AstNode's in a (sub) tree (all occurrence)
+//! // returns an iterator
+//! // Note: only looks through the direct children of the given SyntaxNode
+//! let twig_vars = support::children::<TwigVar>(&tree_root);
+//! # assert_eq!(twig_vars.count(), 1);
+//! ```
+//!
 
 pub use parser::parse;
 pub use parser::Parse;

--- a/crates/ludtwig-parser/src/parser.rs
+++ b/crates/ludtwig-parser/src/parser.rs
@@ -23,6 +23,27 @@ mod source;
 pub(crate) static GENERAL_RECOVERY_SET: &[SyntaxKind] =
     &[T!["{%"], T!["{{"], T!["{#"], T!["<"], T!["<!--"], T!["<!"]];
 
+/// Parses a given string slice (of Twig+HTML code) into a syntax tree.
+///
+/// ## Example
+/// ```
+/// use ludtwig_parser::syntax::untyped::{debug_tree, SyntaxNode};
+///
+/// let parse = ludtwig_parser::parse("{{ 42 }}");
+/// let (tree_root, errors) = parse.split();
+///
+/// assert_eq!(debug_tree(&tree_root), r##"ROOT@0..8
+///   TWIG_VAR@0..8
+///     TK_OPEN_CURLY_CURLY@0..2 "{{"
+///     TWIG_EXPRESSION@2..5
+///       TWIG_LITERAL_NUMBER@2..5
+///         TK_WHITESPACE@2..3 " "
+///         TK_NUMBER@3..5 "42"
+///     TK_WHITESPACE@5..6 " "
+///     TK_CLOSE_CURLY_CURLY@6..8 "}}""##);
+/// ```
+/// More examples can be found at the
+/// [crate level documentation](crate).
 #[must_use]
 pub fn parse(input_text: &str) -> Parse {
     let lex_result = lex(input_text);
@@ -39,6 +60,15 @@ pub struct Parse {
 }
 
 impl Parse {
+    /// Split the parse result into a syntax tree root node and
+    /// the list of parse errors
+    #[must_use]
+    pub fn split(self) -> (SyntaxNode, Vec<ParseError>) {
+        let root = SyntaxNode::new_root(self.green_node.clone());
+
+        (root, self.errors)
+    }
+
     #[must_use]
     pub fn debug_parse(&self) -> String {
         let syntax_node = SyntaxNode::new_root(self.green_node.clone());

--- a/crates/ludtwig-parser/src/syntax.rs
+++ b/crates/ludtwig-parser/src/syntax.rs
@@ -1,2 +1,5 @@
+//! An overview of the syntax structure can be found
+//! at the [crate level documentation](crate#syntax-trees).
+
 pub mod typed;
 pub mod untyped;

--- a/crates/ludtwig-parser/src/syntax/typed.rs
+++ b/crates/ludtwig-parser/src/syntax/typed.rs
@@ -11,10 +11,13 @@ pub use rowan::ast::support;
 pub use rowan::ast::AstChildren;
 pub use rowan::ast::AstNode;
 use rowan::NodeOrToken;
+use std::fmt::{Debug, Display, Formatter};
 
 use crate::T;
 
-use super::untyped::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, TemplateLanguage};
+use super::untyped::{
+    debug_tree, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, TemplateLanguage,
+};
 
 /// So far, we've been working with a homogeneous untyped tree.
 /// It's nice to provide generic tree operations, like traversals,
@@ -29,7 +32,7 @@ use super::untyped::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, Templat
 /// combination of `serde`, `ron` and `tera` crates invaluable for that!
 macro_rules! ast_node {
     ($ast:ident, $kind:path) => {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        #[derive(Clone, PartialEq, Eq, Hash)]
         pub struct $ast {
             pub(crate) syntax: SyntaxNode,
         }
@@ -57,6 +60,20 @@ macro_rules! ast_node {
 
             fn syntax(&self) -> &rowan::SyntaxNode<Self::Language> {
                 &self.syntax
+            }
+        }
+
+        impl Display for $ast {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.syntax)?;
+                Ok(())
+            }
+        }
+
+        impl Debug for $ast {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", debug_tree(&self.syntax))?;
+                Ok(())
             }
         }
     };
@@ -125,9 +142,15 @@ impl HtmlTag {
     #[must_use]
     pub fn name(&self) -> Option<SyntaxToken> {
         match self.starting_tag() {
-            None => None,
             Some(n) => n.name(),
+            None => None,
         }
+    }
+
+    /// Returns true if the tag doesn't have an ending tag
+    #[must_use]
+    pub fn is_self_closing(&self) -> bool {
+        self.ending_tag().is_none()
     }
 
     /// Attributes of the tag
@@ -210,6 +233,12 @@ impl HtmlAttribute {
 
 ast_node!(HtmlEndingTag, SyntaxKind::HTML_ENDING_TAG);
 impl HtmlEndingTag {
+    /// Name of the tag
+    #[must_use]
+    pub fn name(&self) -> Option<SyntaxToken> {
+        support::token(&self.syntax, T![word])
+    }
+
     /// Parent complete html tag
     #[must_use]
     pub fn html_tag(&self) -> Option<HtmlTag> {
@@ -433,7 +462,6 @@ ast_node!(TwigIndexRange, SyntaxKind::TWIG_INDEX_RANGE);
 ast_node!(TwigFunctionCall, SyntaxKind::TWIG_FUNCTION_CALL);
 ast_node!(TwigArguments, SyntaxKind::TWIG_ARGUMENTS);
 ast_node!(TwigNamedArgument, SyntaxKind::TWIG_NAMED_ARGUMENT);
-
 ast_node!(
     TwigLiteralStringInterpolation,
     SyntaxKind::TWIG_LITERAL_STRING_INTERPOLATION
@@ -553,3 +581,93 @@ ast_node!(HtmlText, SyntaxKind::HTML_TEXT);
 ast_node!(HtmlComment, SyntaxKind::HTML_COMMENT);
 ast_node!(Error, SyntaxKind::ERROR);
 ast_node!(Root, SyntaxKind::ROOT);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+    use expect_test::expect;
+
+    fn parse_and_extract<T: AstNode<Language = TemplateLanguage>>(input: &str) -> T {
+        let (tree, errors) = parse(input).split();
+        assert_eq!(errors, vec![]);
+        support::child(&tree).unwrap()
+    }
+
+    #[test]
+    fn simple_html_tag() {
+        let raw = r#"<div class="hello">world {{ 42 }}</div>"#;
+        let html_tag: HtmlTag = parse_and_extract(raw);
+
+        assert_eq!(format!("{html_tag}"), raw.to_string());
+        expect![[r#"
+            HTML_TAG@0..39
+              HTML_STARTING_TAG@0..19
+                TK_LESS_THAN@0..1 "<"
+                TK_WORD@1..4 "div"
+                HTML_ATTRIBUTE_LIST@4..18
+                  HTML_ATTRIBUTE@4..18
+                    TK_WHITESPACE@4..5 " "
+                    TK_WORD@5..10 "class"
+                    TK_EQUAL@10..11 "="
+                    HTML_STRING@11..18
+                      TK_DOUBLE_QUOTES@11..12 "\""
+                      HTML_STRING_INNER@12..17
+                        TK_WORD@12..17 "hello"
+                      TK_DOUBLE_QUOTES@17..18 "\""
+                TK_GREATER_THAN@18..19 ">"
+              BODY@19..33
+                HTML_TEXT@19..24
+                  TK_WORD@19..24 "world"
+                TWIG_VAR@24..33
+                  TK_WHITESPACE@24..25 " "
+                  TK_OPEN_CURLY_CURLY@25..27 "{{"
+                  TWIG_EXPRESSION@27..30
+                    TWIG_LITERAL_NUMBER@27..30
+                      TK_WHITESPACE@27..28 " "
+                      TK_NUMBER@28..30 "42"
+                  TK_WHITESPACE@30..31 " "
+                  TK_CLOSE_CURLY_CURLY@31..33 "}}"
+              HTML_ENDING_TAG@33..39
+                TK_LESS_THAN_SLASH@33..35 "</"
+                TK_WORD@35..38 "div"
+                TK_GREATER_THAN@38..39 ">""#]]
+        .assert_eq(&format!("{html_tag:?}"));
+
+        assert!(!html_tag.is_self_closing());
+        assert_eq!(
+            html_tag.name().map(|t| t.to_string()),
+            Some("div".to_string())
+        );
+        assert_eq!(
+            html_tag.starting_tag().map(|t| t.to_string()),
+            Some(r#"<div class="hello">"#.to_string())
+        );
+        assert_eq!(
+            html_tag.body().map(|t| t.to_string()),
+            Some("world {{ 42 }}".to_string())
+        );
+        assert_eq!(
+            html_tag.ending_tag().map(|t| t.to_string()),
+            Some("</div>".to_string())
+        );
+        assert_eq!(html_tag.attributes().count(), 1);
+        assert_eq!(
+            html_tag
+                .attributes()
+                .next()
+                .and_then(|t| t.name())
+                .map(|t| t.to_string()),
+            Some("class".to_string())
+        );
+        assert_eq!(
+            html_tag
+                .attributes()
+                .next()
+                .and_then(|t| t.value())
+                .and_then(|t| t.get_inner())
+                .map(|t| t.to_string()),
+            Some("hello".to_string())
+        );
+    }
+}

--- a/crates/ludtwig-parser/src/syntax/typed.rs
+++ b/crates/ludtwig-parser/src/syntax/typed.rs
@@ -1,3 +1,12 @@
+//! This module contains all abstract syntax tree (AST) types.
+//! All of them implement the [AstNode] trait.
+//!
+//! Some of them come with extra utility methods, to quickly access some data
+//! (e.g. [TwigBlock::name]).
+//!
+//! An overview of the syntax tree concept can be found
+//! at the [crate level documentation](crate#syntax-trees).
+
 pub use rowan::ast::support;
 pub use rowan::ast::AstChildren;
 pub use rowan::ast::AstNode;
@@ -388,8 +397,23 @@ impl TwigExtends {
     }
 }
 
-ast_node!(Body, SyntaxKind::BODY);
 ast_node!(TwigVar, SyntaxKind::TWIG_VAR);
+impl TwigVar {
+    #[must_use]
+    pub fn get_expression(&self) -> Option<TwigExpression> {
+        support::child(&self.syntax)
+    }
+}
+
+ast_node!(TwigLiteralName, SyntaxKind::TWIG_LITERAL_NAME);
+impl TwigLiteralName {
+    #[must_use]
+    pub fn get_name(&self) -> Option<SyntaxToken> {
+        support::token(&self.syntax, SyntaxKind::TK_WORD)
+    }
+}
+
+ast_node!(Body, SyntaxKind::BODY);
 ast_node!(TwigExpression, SyntaxKind::TWIG_EXPRESSION);
 ast_node!(TwigUnaryExpression, SyntaxKind::TWIG_UNARY_EXPRESSION);
 ast_node!(
@@ -424,7 +448,6 @@ ast_node!(TwigLiteralHashItems, SyntaxKind::TWIG_LITERAL_HASH_ITEMS);
 ast_node!(TwigLiteralHashPair, SyntaxKind::TWIG_LITERAL_HASH_PAIR);
 ast_node!(TwigLiteralHashKey, SyntaxKind::TWIG_LITERAL_HASH_KEY);
 ast_node!(TwigLiteralHashValue, SyntaxKind::TWIG_LITERAL_HASH_VALUE);
-ast_node!(TwigLiteralName, SyntaxKind::TWIG_LITERAL_NAME);
 ast_node!(TwigComment, SyntaxKind::TWIG_COMMENT);
 ast_node!(TwigIf, SyntaxKind::TWIG_IF);
 ast_node!(TwigIfBlock, SyntaxKind::TWIG_IF_BLOCK);

--- a/crates/ludtwig-parser/src/syntax/untyped.rs
+++ b/crates/ludtwig-parser/src/syntax/untyped.rs
@@ -1,3 +1,19 @@
+//! This module contains all the rowan types.
+//!
+//! All GreenNodes and consequently RedNodes as well as AST Nodes
+//! contain a single [SyntaxKind] variant for each GreenNode.
+//!
+//! You can use the macro (T![])[crate::T] to quickly construct a [SyntaxKind]
+//! and for example compare it to a different one. For example
+//! ```
+//! use ludtwig_parser::syntax::untyped::SyntaxKind;
+//! use ludtwig_parser::T;
+//! assert_eq!(T!["%}"], SyntaxKind::TK_PERCENT_CURLY);
+//! ```
+//!
+//! An overview of the syntax tree concept can be found
+//! at the [crate level documentation](crate#syntax-trees).
+
 use logos::Logos;
 pub use rowan::Direction;
 /// `GreenNode` is an immutable tree, which is cheap to change,


### PR DESCRIPTION
Added proper documentation for the parser crate and modules that hopefully explains how it works a bit better and references [Syntax in rust-analyzer](https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/syntax.md) for more details.

Also added some more AST implementations to more easily get some of the syntax tree nodes (e.g. if a HTML tag is self closing or the name of the HTML ending tag). There are still many such implementations missing and you likely still have to reach into the red tree yourself, but let's try to improve this further as more are needed inside Ludtwigs rules.