### PR TITLE
feat: implement missing twig component syntax

### DIFF
--- a/crates/ludtwig-parser/src/grammar/twig.rs
+++ b/crates/ludtwig-parser/src/grammar/twig.rs
@@ -141,7 +141,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_twig_component_call() {
+    fn parse_twig_function_call() {
         check_parse(
             "{{ component('Alert', { message: 'Hello Twig Components!' }) }}",
             expect![[r#"

--- a/crates/ludtwig-parser/src/grammar/twig/tags.rs
+++ b/crates/ludtwig-parser/src/grammar/twig/tags.rs
@@ -86,6 +86,8 @@ pub(crate) fn parse_twig_block_statement(
         Some(parse_twig_cache(parser, m, child_parser))
     } else if parser.at(T!["trans"]) {
         Some(parse_twig_trans(parser, m, child_parser))
+    } else if parser.at(T!["props"]) {
+        Some(parse_twig_props(parser, m))
     } else {
         match parse_shopware_twig_block_statement(parser, m, child_parser) {
             BlockParseResult::NothingFound(m) => {
@@ -1082,6 +1084,41 @@ fn parse_twig_trans(
     parser.complete(end_block_m, SyntaxKind::TWIG_TRANS_ENDING_BLOCK);
 
     parser.complete(wrapper_m, SyntaxKind::TWIG_TRANS)
+}
+
+fn parse_twig_props(parser: &mut Parser, outer: Marker) -> CompletedMarker {
+    // example:
+    // {% props icon = null, type = 'primary' %}
+
+    debug_assert!(parser.at(T!["props"]));
+    parser.bump();
+
+    parse_many(
+        parser,
+        |p| p.at_set(&[T!["%}"], T![","], T!["="], T!["</"]]),
+        |p| {
+            let m = p.start();
+            if parse_twig_name(p).is_none() {
+                p.add_error(ParseErrorBuilder::new("twig variable name"));
+            }
+
+            p.expect(T!["="], &[T![","], T!["%}"], T!["</"]]);
+
+            if parse_twig_expression(p).is_none() {
+                p.add_error(ParseErrorBuilder::new("twig expression"));
+            }
+            p.complete(m, SyntaxKind::TWIG_PROP_DECLARATION);
+
+            if p.at(T![","]) {
+                p.bump();
+            } else if !p.at(T!["%}"]) {
+                p.add_error(ParseErrorBuilder::new(","));
+            }
+        },
+    );
+
+    parser.expect(T!["%}"], &[T!["</"]]);
+    parser.complete(outer, SyntaxKind::TWIG_PROPS)
 }
 
 #[cfg(test)]
@@ -5230,6 +5267,221 @@ mod tests {
                     TK_ENDTRANS@27..35 "endtrans"
                     TK_WHITESPACE@35..36 " "
                     TK_PERCENT_CURLY@36..38 "%}""#]],
+        );
+    }
+
+    #[test]
+    fn parse_twig_props_declaration() {
+        check_parse(
+            "{% props icon = null, type = 'primary' %}",
+            expect![[r#"
+                ROOT@0..41
+                  TWIG_PROPS@0..41
+                    TK_CURLY_PERCENT@0..2 "{%"
+                    TK_WHITESPACE@2..3 " "
+                    TK_PROPS@3..8 "props"
+                    TWIG_PROP_DECLARATION@8..20
+                      TWIG_LITERAL_NAME@8..13
+                        TK_WHITESPACE@8..9 " "
+                        TK_WORD@9..13 "icon"
+                      TK_WHITESPACE@13..14 " "
+                      TK_EQUAL@14..15 "="
+                      TWIG_EXPRESSION@15..20
+                        TWIG_LITERAL_NULL@15..20
+                          TK_WHITESPACE@15..16 " "
+                          TK_NULL@16..20 "null"
+                    TK_COMMA@20..21 ","
+                    TWIG_PROP_DECLARATION@21..38
+                      TWIG_LITERAL_NAME@21..26
+                        TK_WHITESPACE@21..22 " "
+                        TK_WORD@22..26 "type"
+                      TK_WHITESPACE@26..27 " "
+                      TK_EQUAL@27..28 "="
+                      TWIG_EXPRESSION@28..38
+                        TWIG_LITERAL_STRING@28..38
+                          TK_WHITESPACE@28..29 " "
+                          TK_SINGLE_QUOTES@29..30 "'"
+                          TWIG_LITERAL_STRING_INNER@30..37
+                            TK_WORD@30..37 "primary"
+                          TK_SINGLE_QUOTES@37..38 "'"
+                    TK_WHITESPACE@38..39 " "
+                    TK_PERCENT_CURLY@39..41 "%}""#]],
+        );
+    }
+
+    #[test]
+    fn parse_twig_full_twig_component_declaration() {
+        check_parse(
+            r#"{% props icon = null, type = 'primary' %}
+
+<button {{ attributes.defaults({class: 'btn btn-'~type}) }}>
+    {% block content %}{% endblock %}
+    {% if icon %}
+        <span class="fa-solid fa-{{ icon }}"></span>
+    {% endif %}
+</button>"#,
+            expect![[r#"
+                ROOT@0..238
+                  TWIG_PROPS@0..41
+                    TK_CURLY_PERCENT@0..2 "{%"
+                    TK_WHITESPACE@2..3 " "
+                    TK_PROPS@3..8 "props"
+                    TWIG_PROP_DECLARATION@8..20
+                      TWIG_LITERAL_NAME@8..13
+                        TK_WHITESPACE@8..9 " "
+                        TK_WORD@9..13 "icon"
+                      TK_WHITESPACE@13..14 " "
+                      TK_EQUAL@14..15 "="
+                      TWIG_EXPRESSION@15..20
+                        TWIG_LITERAL_NULL@15..20
+                          TK_WHITESPACE@15..16 " "
+                          TK_NULL@16..20 "null"
+                    TK_COMMA@20..21 ","
+                    TWIG_PROP_DECLARATION@21..38
+                      TWIG_LITERAL_NAME@21..26
+                        TK_WHITESPACE@21..22 " "
+                        TK_WORD@22..26 "type"
+                      TK_WHITESPACE@26..27 " "
+                      TK_EQUAL@27..28 "="
+                      TWIG_EXPRESSION@28..38
+                        TWIG_LITERAL_STRING@28..38
+                          TK_WHITESPACE@28..29 " "
+                          TK_SINGLE_QUOTES@29..30 "'"
+                          TWIG_LITERAL_STRING_INNER@30..37
+                            TK_WORD@30..37 "primary"
+                          TK_SINGLE_QUOTES@37..38 "'"
+                    TK_WHITESPACE@38..39 " "
+                    TK_PERCENT_CURLY@39..41 "%}"
+                  HTML_TAG@41..238
+                    HTML_STARTING_TAG@41..103
+                      TK_LINE_BREAK@41..43 "\n\n"
+                      TK_LESS_THAN@43..44 "<"
+                      TK_WORD@44..50 "button"
+                      HTML_ATTRIBUTE_LIST@50..102
+                        HTML_ATTRIBUTE@50..102
+                          TWIG_VAR@50..102
+                            TK_WHITESPACE@50..51 " "
+                            TK_OPEN_CURLY_CURLY@51..53 "{{"
+                            TWIG_EXPRESSION@53..99
+                              TWIG_FUNCTION_CALL@53..99
+                                TWIG_OPERAND@53..73
+                                  TWIG_ACCESSOR@53..73
+                                    TWIG_OPERAND@53..64
+                                      TWIG_LITERAL_NAME@53..64
+                                        TK_WHITESPACE@53..54 " "
+                                        TK_WORD@54..64 "attributes"
+                                    TK_DOT@64..65 "."
+                                    TWIG_OPERAND@65..73
+                                      TWIG_LITERAL_NAME@65..73
+                                        TK_WORD@65..73 "defaults"
+                                TWIG_ARGUMENTS@73..99
+                                  TK_OPEN_PARENTHESIS@73..74 "("
+                                  TWIG_EXPRESSION@74..98
+                                    TWIG_LITERAL_HASH@74..98
+                                      TK_OPEN_CURLY@74..75 "{"
+                                      TWIG_LITERAL_HASH_ITEMS@75..97
+                                        TWIG_LITERAL_HASH_PAIR@75..97
+                                          TWIG_LITERAL_HASH_KEY@75..80
+                                            TK_WORD@75..80 "class"
+                                          TK_COLON@80..81 ":"
+                                          TWIG_EXPRESSION@81..97
+                                            TWIG_BINARY_EXPRESSION@81..97
+                                              TWIG_EXPRESSION@81..92
+                                                TWIG_LITERAL_STRING@81..92
+                                                  TK_WHITESPACE@81..82 " "
+                                                  TK_SINGLE_QUOTES@82..83 "'"
+                                                  TWIG_LITERAL_STRING_INNER@83..91
+                                                    TK_WORD@83..86 "btn"
+                                                    TK_WHITESPACE@86..87 " "
+                                                    TK_WORD@87..91 "btn-"
+                                                  TK_SINGLE_QUOTES@91..92 "'"
+                                              TK_TILDE@92..93 "~"
+                                              TWIG_EXPRESSION@93..97
+                                                TWIG_LITERAL_NAME@93..97
+                                                  TK_WORD@93..97 "type"
+                                      TK_CLOSE_CURLY@97..98 "}"
+                                  TK_CLOSE_PARENTHESIS@98..99 ")"
+                            TK_WHITESPACE@99..100 " "
+                            TK_CLOSE_CURLY_CURLY@100..102 "}}"
+                      TK_GREATER_THAN@102..103 ">"
+                    BODY@103..228
+                      TWIG_BLOCK@103..141
+                        TWIG_STARTING_BLOCK@103..127
+                          TK_LINE_BREAK@103..104 "\n"
+                          TK_WHITESPACE@104..108 "    "
+                          TK_CURLY_PERCENT@108..110 "{%"
+                          TK_WHITESPACE@110..111 " "
+                          TK_BLOCK@111..116 "block"
+                          TK_WHITESPACE@116..117 " "
+                          TK_WORD@117..124 "content"
+                          TK_WHITESPACE@124..125 " "
+                          TK_PERCENT_CURLY@125..127 "%}"
+                        BODY@127..127
+                        TWIG_ENDING_BLOCK@127..141
+                          TK_CURLY_PERCENT@127..129 "{%"
+                          TK_WHITESPACE@129..130 " "
+                          TK_ENDBLOCK@130..138 "endblock"
+                          TK_WHITESPACE@138..139 " "
+                          TK_PERCENT_CURLY@139..141 "%}"
+                      TWIG_IF@141..228
+                        TWIG_IF_BLOCK@141..159
+                          TK_LINE_BREAK@141..142 "\n"
+                          TK_WHITESPACE@142..146 "    "
+                          TK_CURLY_PERCENT@146..148 "{%"
+                          TK_WHITESPACE@148..149 " "
+                          TK_IF@149..151 "if"
+                          TWIG_EXPRESSION@151..156
+                            TWIG_LITERAL_NAME@151..156
+                              TK_WHITESPACE@151..152 " "
+                              TK_WORD@152..156 "icon"
+                          TK_WHITESPACE@156..157 " "
+                          TK_PERCENT_CURLY@157..159 "%}"
+                        BODY@159..212
+                          HTML_TAG@159..212
+                            HTML_STARTING_TAG@159..205
+                              TK_LINE_BREAK@159..160 "\n"
+                              TK_WHITESPACE@160..168 "        "
+                              TK_LESS_THAN@168..169 "<"
+                              TK_WORD@169..173 "span"
+                              HTML_ATTRIBUTE_LIST@173..204
+                                HTML_ATTRIBUTE@173..204
+                                  TK_WHITESPACE@173..174 " "
+                                  TK_WORD@174..179 "class"
+                                  TK_EQUAL@179..180 "="
+                                  HTML_STRING@180..204
+                                    TK_DOUBLE_QUOTES@180..181 "\""
+                                    HTML_STRING_INNER@181..203
+                                      TK_WORD@181..189 "fa-solid"
+                                      TK_WHITESPACE@189..190 " "
+                                      TK_WORD@190..193 "fa-"
+                                      TWIG_VAR@193..203
+                                        TK_OPEN_CURLY_CURLY@193..195 "{{"
+                                        TWIG_EXPRESSION@195..200
+                                          TWIG_LITERAL_NAME@195..200
+                                            TK_WHITESPACE@195..196 " "
+                                            TK_WORD@196..200 "icon"
+                                        TK_WHITESPACE@200..201 " "
+                                        TK_CLOSE_CURLY_CURLY@201..203 "}}"
+                                    TK_DOUBLE_QUOTES@203..204 "\""
+                              TK_GREATER_THAN@204..205 ">"
+                            BODY@205..205
+                            HTML_ENDING_TAG@205..212
+                              TK_LESS_THAN_SLASH@205..207 "</"
+                              TK_WORD@207..211 "span"
+                              TK_GREATER_THAN@211..212 ">"
+                        TWIG_ENDIF_BLOCK@212..228
+                          TK_LINE_BREAK@212..213 "\n"
+                          TK_WHITESPACE@213..217 "    "
+                          TK_CURLY_PERCENT@217..219 "{%"
+                          TK_WHITESPACE@219..220 " "
+                          TK_ENDIF@220..225 "endif"
+                          TK_WHITESPACE@225..226 " "
+                          TK_PERCENT_CURLY@226..228 "%}"
+                    HTML_ENDING_TAG@228..238
+                      TK_LINE_BREAK@228..229 "\n"
+                      TK_LESS_THAN_SLASH@229..231 "</"
+                      TK_WORD@231..237 "button"
+                      TK_GREATER_THAN@237..238 ">""#]],
         );
     }
 }

--- a/crates/ludtwig-parser/src/lexer.rs
+++ b/crates/ludtwig-parser/src/lexer.rs
@@ -256,6 +256,7 @@ mod tests {
         add("endwith", T!["endwith"]);
         add("ttl", T!["ttl"]);
         add("tags", T!["tags"]);
+        add("props", T!["props"]);
         add("not", T!["not"]);
         add("or", T!["or"]);
         add("and", T!["and"]);
@@ -835,6 +836,11 @@ mod tests {
     #[test]
     fn lex_tags() {
         check_token("tags", T!["tags"]);
+    }
+
+    #[test]
+    fn lex_props() {
+        check_token("props", T!["props"]);
     }
 
     #[test]

--- a/crates/ludtwig-parser/src/syntax/typed.rs
+++ b/crates/ludtwig-parser/src/syntax/typed.rs
@@ -556,6 +556,8 @@ ast_node!(
     SyntaxKind::TWIG_CACHE_STARTING_BLOCK
 );
 ast_node!(TwigCacheEndingBlock, SyntaxKind::TWIG_CACHE_ENDING_BLOCK);
+ast_node!(TwigProps, SyntaxKind::TWIG_PROPS);
+ast_node!(TwigPropDeclaration, SyntaxKind::TWIG_PROP_DECLARATION);
 ast_node!(ShopwareTwigExtends, SyntaxKind::SHOPWARE_TWIG_SW_EXTENDS);
 ast_node!(ShopwareTwigInclude, SyntaxKind::SHOPWARE_TWIG_SW_INCLUDE);
 ast_node!(

--- a/crates/ludtwig-parser/src/syntax/untyped.rs
+++ b/crates/ludtwig-parser/src/syntax/untyped.rs
@@ -244,6 +244,8 @@ pub enum SyntaxKind {
     TK_TTL,
     #[token("tags")]
     TK_TAGS,
+    #[token("props")]
+    TK_PROPS,
     /* twig operators */
     #[token("not")]
     TK_NOT,
@@ -454,6 +456,9 @@ pub enum SyntaxKind {
     TWIG_CACHE_TAGS,
     TWIG_CACHE_STARTING_BLOCK,
     TWIG_CACHE_ENDING_BLOCK,
+    // twig props
+    TWIG_PROPS,
+    TWIG_PROP_DECLARATION,
 
     // Drupal Trans
     TWIG_TRANS,
@@ -598,6 +603,7 @@ macro_rules! T {
     ["endwith"] => { $crate::syntax::untyped::SyntaxKind::TK_ENDWITH };
     ["ttl"] => { $crate::syntax::untyped::SyntaxKind::TK_TTL };
     ["tags"] => { $crate::syntax::untyped::SyntaxKind::TK_TAGS };
+    ["props"] => { $crate::syntax::untyped::SyntaxKind::TK_PROPS };
     ["not"] => { $crate::syntax::untyped::SyntaxKind::TK_NOT };
     ["or"] => { $crate::syntax::untyped::SyntaxKind::TK_OR };
     ["and"] => { $crate::syntax::untyped::SyntaxKind::TK_AND };
@@ -752,6 +758,7 @@ impl fmt::Display for SyntaxKind {
             SyntaxKind::TK_ENDWITH => "endwith",
             SyntaxKind::TK_TTL => "ttl",
             SyntaxKind::TK_TAGS => "tags",
+            SyntaxKind::TK_PROPS => "props",
             SyntaxKind::TK_NOT => "not",
             SyntaxKind::TK_OR => "or",
             SyntaxKind::TK_AND => "and",


### PR DESCRIPTION
Open todos:
- [ ] [non-html syntax for twig components](https://symfony.com/bundles/ux-twig-component/current/index.html#passing-html-to-components-via-blocks)
- [ ] more tests, ideally grep all example from the symfony docs about twig components


closes #130