### PR TITLE
feat: new json encode escape js rule

### DIFF
--- a/crates/ludtwig/ludtwig-config.toml
+++ b/crates/ludtwig/ludtwig-config.toml
@@ -42,6 +42,7 @@ active-rules = [
     "twig-string-quotation",
     "html-string-quotation",
     "twig-hash-key-no-quotes",
+    "twig-json-encode-escape-js",
     "twig-use-is-same-as",
     "twig-use-is-not-same-as",
     "twig-prefer-shopware-extends",

--- a/crates/ludtwig/src/check/rules.rs
+++ b/crates/ludtwig/src/check/rules.rs
@@ -9,6 +9,7 @@ use crate::check::rules::twig_block_line_breaks::RuleTwigBlockLineBreaks;
 use crate::check::rules::twig_block_name_snake_case::RuleTwigBlockNameSnakeCase;
 use crate::check::rules::twig_hash_key_no_quotes::RuleTwigHashKeyNoQuotes;
 use crate::check::rules::twig_logic_and::RuleTwigLogicAnd;
+use crate::check::rules::twig_json_encode_escape_js::RuleTwigJsonEncodeEscapeJs;
 use crate::check::rules::twig_logic_or::RuleTwigLogicOr;
 use crate::check::rules::twig_prefer_shopware_extends::RuleTwigPreferShopwareExtends;
 use crate::check::rules::twig_string_quotation::RuleTwigStringQuotation;
@@ -31,6 +32,7 @@ mod twig_block_name_snake_case;
 mod twig_hash_key_no_quotes;
 mod twig_logic_and;
 mod twig_logic_or;
+mod twig_json_encode_escape_js;
 mod twig_prefer_shopware_extends;
 mod twig_string_quotation;
 mod twig_use_is_not_same_as;
@@ -51,6 +53,7 @@ pub static RULE_DEFINITIONS: &[&'static dyn Rule] = &[
     &RuleTwigStringQuotation,
     &RuleHtmlStringQuotation,
     &RuleTwigHashKeyNoQuotes,
+    &RuleTwigJsonEncodeEscapeJs,
     &RuleTwigPreferShopwareExtends,
     &RuleTwigUseIsSameAs,
     &RuleTwigUseIsNotSameAs,

--- a/crates/ludtwig/src/check/rules/twig_json_encode_escape_js.rs
+++ b/crates/ludtwig/src/check/rules/twig_json_encode_escape_js.rs
@@ -1,0 +1,140 @@
+use ludtwig_parser::syntax::typed::{support, AstNode, TwigFilter, TwigLiteralName, TwigOperand};
+use ludtwig_parser::syntax::untyped::SyntaxNode;
+
+use crate::check::rule::{CheckResult, Rule, RuleExt, RuleRunContext, Severity};
+
+pub struct RuleTwigJsonEncodeEscapeJs;
+
+impl Rule for RuleTwigJsonEncodeEscapeJs {
+    fn name(&self) -> &'static str {
+        "twig-json-encode-escape-js"
+    }
+
+    fn check_node(&self, node: SyntaxNode, _ctx: &RuleRunContext) -> Option<Vec<CheckResult>> {
+        let filter = TwigFilter::cast(node)?;
+
+        // Identify the current (right-most) filter name for this TWIG_FILTER node
+        let right_operand: TwigOperand = support::children(&filter.syntax()).nth(1)?;
+        let right_name_node: TwigLiteralName = support::child(right_operand.syntax())?;
+        let right_name_token = right_name_node.get_name()?;
+        let right_name = right_name_token.text();
+
+        // Trigger only when the current filter is `raw`
+        if right_name != "raw" {
+            return None;
+        }
+
+        // Walk nested filter chain leftwards and check if any filter is `json_encode`
+        if !chain_contains_json_encode(&filter) {
+            return None;
+        }
+
+        // Report and suggest replacing `raw` with `escape('js')`
+        let result = self
+            .create_result(Severity::Error, "avoid raw after json_encode; use escape('js')")
+            .primary_note(
+                right_name_token.text_range(),
+                "help: replace 'raw' with escape('js')",
+            )
+            .suggestion(
+                right_name_token.text_range(),
+                "escape('js')",
+                "Try this filter instead",
+            );
+
+        Some(vec![result])
+    }
+}
+
+fn chain_contains_json_encode(filter: &TwigFilter) -> bool {
+    let mut current = filter.clone();
+    loop {
+        // Check current TWIG_FILTER's right-hand filter name
+        if let Some(right_operand) = support::children::<TwigOperand>(&current.syntax()).nth(1) {
+            if let Some(name_node) = support::child::<TwigLiteralName>(right_operand.syntax()) {
+                if name_node
+                    .get_name()
+                    .is_some_and(|t| t.text() == "json_encode")
+                {
+                    return true;
+                }
+            }
+        }
+
+        // Step into the left side; if it's another TWIG_FILTER, continue; otherwise stop
+        if let Some(left_operand) = support::children::<TwigOperand>(&current.syntax()).next() {
+            if let Some(inner) = support::child::<TwigFilter>(left_operand.syntax()) {
+                current = inner;
+                continue;
+            }
+        }
+
+        break;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::check::rules::test::{
+        test_rule_does_not_fix, test_rule_fix,
+    };
+    use expect_test::expect;
+
+    #[test]
+    fn fixes_simple_chain() {
+        test_rule_fix(
+            "twig-json-encode-escape-js",
+            "{{ a|json_encode|raw }}",
+            expect!["{{ a|json_encode|escape('js') }}"],
+        );
+    }
+
+    #[test]
+    fn fixes_with_json_encode_args() {
+        test_rule_fix(
+            "twig-json-encode-escape-js",
+            "{{ breakpoint|json_encode()|raw }}",
+            expect!["{{ breakpoint|json_encode()|escape('js') }}"],
+        );
+    }
+
+    #[test]
+    fn fixes_inside_html_attribute() {
+        test_rule_fix(
+            "twig-json-encode-escape-js",
+            "data-magnifier-options='{{ magnifierOptions|json_encode|raw }}'",
+            expect!["data-magnifier-options='{{ magnifierOptions|json_encode|escape('js') }}'"],
+        );
+    }
+
+    #[test]
+    fn fixes_with_function_call() {
+        test_rule_fix(
+            "twig-json-encode-escape-js",
+            "{{ getAllFeatures()|json_encode|raw }}",
+            expect!["{{ getAllFeatures()|json_encode|escape('js') }}"],
+        );
+    }
+
+    #[test]
+    fn does_not_change_raw_without_json_encode() {
+        test_rule_does_not_fix(
+            "twig-json-encode-escape-js",
+            "{{ a|raw }}",
+            expect!["{{ a|raw }}"],
+        );
+    }
+
+    #[test]
+    fn does_not_change_when_already_escaped_js() {
+        test_rule_does_not_fix(
+            "twig-json-encode-escape-js",
+            "{{ a|json_encode|escape('js') }}",
+            expect!["{{ a|json_encode|escape('js') }}"],
+        );
+    }
+}
+
+


### PR DESCRIPTION
Introduce a new lint rule to avoid raw when using json_encode and suggest using escape JS.