### PR TITLE
fix: end_sw_embed token

### DIFF
--- a/crates/ludtwig-parser/src/grammar/twig/tags.rs
+++ b/crates/ludtwig-parser/src/grammar/twig/tags.rs
@@ -28,7 +28,7 @@ pub(crate) fn at_twig_termination_tag(p: &mut Parser) -> bool {
         T!["endset"],
         T!["endfor"],
         T!["endembed"],
-        T!["sw_end_embed"],
+        T!["end_sw_embed"],
         T!["endapply"],
         T!["endautoescape"],
         T!["endsandbox"],
@@ -782,7 +782,7 @@ fn parse_twig_embed(
     parser.bump();
 
     let expected_end_tag = if is_sw_embed {
-        T!["sw_end_embed"]
+        T!["end_sw_embed"]
     } else {
         T!["endembed"]
     };
@@ -795,7 +795,7 @@ fn parse_twig_embed(
             T!["with"],
             T!["only"],
             T!["endembed"],
-            T!["sw_end_embed"],
+            T!["end_sw_embed"],
             T!["%}"],
             T!["-%}"],
             T!["~%}"],
@@ -815,7 +815,7 @@ fn parse_twig_embed(
             parser.recover(&[
                 T!["only"],
                 T!["endembed"],
-                T!["sw_end_embed"],
+                T!["end_sw_embed"],
                 T!["%}"],
                 T!["-%}"],
                 T!["~%}"],
@@ -833,7 +833,7 @@ fn parse_twig_embed(
         TWIG_BLOCK_CLOSE_SET,
         &[
             T!["endembed"],
-            T!["sw_end_embed"],
+            T!["end_sw_embed"],
             T!["%}"],
             T!["-%}"],
             T!["~%}"],
@@ -849,7 +849,7 @@ fn parse_twig_embed(
     let body_m = parser.start();
     parse_many(
         parser,
-        |p| p.at_twig_tag(T!["endembed"]) || p.at_twig_tag(T!["sw_end_embed"]),
+        |p| p.at_twig_tag(T!["endembed"]) || p.at_twig_tag(T!["end_sw_embed"]),
         |p| {
             child_parser(p);
         },
@@ -861,7 +861,7 @@ fn parse_twig_embed(
         TWIG_BLOCK_OPEN_SET,
         &[
             T!["endembed"],
-            T!["sw_end_embed"],
+            T!["end_sw_embed"],
             T!["%}"],
             T!["-%}"],
             T!["~%}"],
@@ -6142,9 +6142,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_sw_embed_alias_with_sw_end_embed() {
+    fn parse_sw_embed_alias_with_end_sw_embed() {
         check_parse(
-            "{% sw_embed 'base.html.twig' %}...{% sw_end_embed %}",
+            "{% sw_embed 'base.html.twig' %}...{% end_sw_embed %}",
             expect![[r#"
                 ROOT@0..52
                   TWIG_EMBED@0..52
@@ -6171,7 +6171,7 @@ mod tests {
                     TWIG_EMBED_ENDING_BLOCK@34..52
                       TK_CURLY_PERCENT@34..36 "{%"
                       TK_WHITESPACE@36..37 " "
-                      TK_SW_END_EMBED@37..49 "sw_end_embed"
+                      TK_END_SW_EMBED@37..49 "end_sw_embed"
                       TK_WHITESPACE@49..50 " "
                       TK_PERCENT_CURLY@50..52 "%}""#]],
         );

--- a/crates/ludtwig-parser/src/lexer.rs
+++ b/crates/ludtwig-parser/src/lexer.rs
@@ -318,7 +318,7 @@ mod tests {
         add("trans", T!["trans"]);
         add("endtrans", T!["endtrans"]);
         add("sw_embed", T!["sw_embed"]);
-        add("sw_end_embed", T!["sw_end_embed"]);
+        add("end_sw_embed", T!["end_sw_embed"]);
         add("sw_use", T!["sw_use"]);
         add("sw_import", T!["sw_import"]);
         add("sw_from", T!["sw_from"]);
@@ -1108,8 +1108,8 @@ mod tests {
     }
 
     #[test]
-    fn lex_sw_end_embed() {
-        check_token("sw_end_embed", T!["sw_end_embed"]);
+    fn lex_end_sw_embed() {
+        check_token("end_sw_embed", T!["end_sw_embed"]);
     }
 
     #[test]

--- a/crates/ludtwig-parser/src/syntax/untyped.rs
+++ b/crates/ludtwig-parser/src/syntax/untyped.rs
@@ -370,8 +370,8 @@ pub enum SyntaxKind {
     TK_STYLE,
     #[token("sw_embed")]
     TK_SW_EMBED,
-    #[token("sw_end_embed")]
-    TK_SW_END_EMBED,
+    #[token("end_sw_embed")]
+    TK_END_SW_EMBED,
     #[token("sw_use")]
     TK_SW_USE,
     #[token("sw_import")]
@@ -744,7 +744,7 @@ macro_rules! T {
     ["sw_thumbnails"] => { $crate::syntax::untyped::SyntaxKind::TK_SW_THUMBNAILS };
     ["style"] => { $crate::syntax::untyped::SyntaxKind::TK_STYLE };
     ["sw_embed"] => { $crate::syntax::untyped::SyntaxKind::TK_SW_EMBED };
-    ["sw_end_embed"] => { $crate::syntax::untyped::SyntaxKind::TK_SW_END_EMBED };
+    ["end_sw_embed"] => { $crate::syntax::untyped::SyntaxKind::TK_END_SW_EMBED };
     ["sw_use"] => { $crate::syntax::untyped::SyntaxKind::TK_SW_USE };
     ["sw_import"] => { $crate::syntax::untyped::SyntaxKind::TK_SW_IMPORT };
     ["sw_from"] => { $crate::syntax::untyped::SyntaxKind::TK_SW_FROM };
@@ -914,7 +914,7 @@ impl fmt::Display for SyntaxKind {
             SyntaxKind::TK_SW_THUMBNAILS => "sw_thumbnails",
             SyntaxKind::TK_STYLE => "style",
             SyntaxKind::TK_SW_EMBED => "sw_embed",
-            SyntaxKind::TK_SW_END_EMBED => "sw_end_embed",
+            SyntaxKind::TK_END_SW_EMBED => "end_sw_embed",
             SyntaxKind::TK_SW_USE => "sw_use",
             SyntaxKind::TK_SW_IMPORT => "sw_import",
             SyntaxKind::TK_SW_FROM => "sw_from",


### PR DESCRIPTION
I made a mistake by adding the wrong sw_embed end token in #173. Should be `end_sw_embed` instead of `sw_end_embed` ([see](https://github.com/shopware/shopware/blob/673b0a55c5c632d5b1df31311e1bb64c7117ccf3/src/Core/Framework/Adapter/Twig/TokenParser/EmbedTokenParser.php#L76)).