### PR TITLE
fix: attribute string with chevron

### DIFF
--- a/crates/ludtwig-parser/CHANGELOG.md
+++ b/crates/ludtwig-parser/CHANGELOG.md
@@ -1,5 +1,7 @@
 # NEXT-VERSION
 
+- [#189](https://github.com/MalteJanz/ludtwig/issues/189) Fix parser crash when an HTML attribute value contains `>` inside a quoted string (e.g. `data-prop=">"`)
+
 # v0.10.0
 
 - [#179](https://github.com/MalteJanz/ludtwig/pull/179) Support parentheses-optional syntax for `same as` and

--- a/crates/ludtwig-parser/src/grammar/html.rs
+++ b/crates/ludtwig-parser/src/grammar/html.rs
@@ -333,7 +333,10 @@ fn parse_html_attribute_value_string(parser: &mut Parser) -> CompletedMarker {
                 if p.at(T!("\"")) {
                     return true;
                 }
-
+                // Stop at '>' only when there is no closing '"' before the next HTML tag-boundary token.
+                if p.at_set(&[T![">"], T!["/>"]]) {
+                    return !p.has_closing_quote_before_tag_boundary(T!["\""]);
+                }
                 at_twig_termination_tag(p)
             },
             |p| child_parser(p, inner_double_quote_parser),
@@ -348,7 +351,10 @@ fn parse_html_attribute_value_string(parser: &mut Parser) -> CompletedMarker {
                 if p.at(T!("'")) {
                     return true;
                 }
-
+                // Stop at '>' only when there is no closing '"' before the next HTML tag-boundary token.
+                if p.at_set(&[T![">"], T!["/>"]]) {
+                    return !p.has_closing_quote_before_tag_boundary(T!["'"]);
+                }
                 at_twig_termination_tag(p)
             },
             |p| child_parser(p, inner_single_quote_parser),
@@ -372,7 +378,7 @@ fn parse_html_attribute_value_string(parser: &mut Parser) -> CompletedMarker {
 
     fn child_parser(p: &mut Parser, inner_twig_child_parser: ParseFunction) {
         if parse_any_twig(p, inner_twig_child_parser).is_none() {
-            if p.at_set(&[T![">"], T!["/>"]]) || p.at_set(GENERAL_RECOVERY_SET) || p.at_end() {
+            if p.at_set(GENERAL_RECOVERY_SET) || p.at_end() {
                 return;
             }
 
@@ -2793,6 +2799,72 @@ mod tests {
                       TK_LESS_THAN_SLASH@29..31 "</"
                       TK_WORD@31..36 "title"
                       TK_GREATER_THAN@36..37 ">""#]],
+        );
+    }
+
+    #[test]
+    fn parse_html_attribute_value_string_with_greater_than_double_quote() {
+        check_parse(
+            r#"<div data-prop=">">Hello world</div>"#,
+            expect![[r#"
+                ROOT@0..36
+                  HTML_TAG@0..36
+                    HTML_STARTING_TAG@0..19
+                      TK_LESS_THAN@0..1 "<"
+                      TK_WORD@1..4 "div"
+                      HTML_ATTRIBUTE_LIST@4..18
+                        HTML_ATTRIBUTE@4..18
+                          TK_WHITESPACE@4..5 " "
+                          TK_WORD@5..14 "data-prop"
+                          TK_EQUAL@14..15 "="
+                          HTML_STRING@15..18
+                            TK_DOUBLE_QUOTES@15..16 "\""
+                            HTML_STRING_INNER@16..17
+                              TK_GREATER_THAN@16..17 ">"
+                            TK_DOUBLE_QUOTES@17..18 "\""
+                      TK_GREATER_THAN@18..19 ">"
+                    BODY@19..30
+                      HTML_TEXT@19..30
+                        TK_WORD@19..24 "Hello"
+                        TK_WHITESPACE@24..25 " "
+                        TK_WORD@25..30 "world"
+                    HTML_ENDING_TAG@30..36
+                      TK_LESS_THAN_SLASH@30..32 "</"
+                      TK_WORD@32..35 "div"
+                      TK_GREATER_THAN@35..36 ">""#]],
+        );
+    }
+
+    #[test]
+    fn parse_html_attribute_value_string_with_greater_than_single_quote() {
+        check_parse(
+            r#"<div data-prop='>'>Hello world</div>"#,
+            expect![[r#"
+                ROOT@0..36
+                  HTML_TAG@0..36
+                    HTML_STARTING_TAG@0..19
+                      TK_LESS_THAN@0..1 "<"
+                      TK_WORD@1..4 "div"
+                      HTML_ATTRIBUTE_LIST@4..18
+                        HTML_ATTRIBUTE@4..18
+                          TK_WHITESPACE@4..5 " "
+                          TK_WORD@5..14 "data-prop"
+                          TK_EQUAL@14..15 "="
+                          HTML_STRING@15..18
+                            TK_SINGLE_QUOTES@15..16 "'"
+                            HTML_STRING_INNER@16..17
+                              TK_GREATER_THAN@16..17 ">"
+                            TK_SINGLE_QUOTES@17..18 "'"
+                      TK_GREATER_THAN@18..19 ">"
+                    BODY@19..30
+                      HTML_TEXT@19..30
+                        TK_WORD@19..24 "Hello"
+                        TK_WHITESPACE@24..25 " "
+                        TK_WORD@25..30 "world"
+                    HTML_ENDING_TAG@30..36
+                      TK_LESS_THAN_SLASH@30..32 "</"
+                      TK_WORD@32..35 "div"
+                      TK_GREATER_THAN@35..36 ">""#]],
         );
     }
 }

--- a/crates/ludtwig-parser/src/parser.rs
+++ b/crates/ludtwig-parser/src/parser.rs
@@ -172,6 +172,15 @@ impl<'source> Parser<'source> {
         self.source.peek_next_non_trivia_kind()
     }
 
+    /// Scans ahead to check if `closing_kind` appears before any HTML tag-boundary token
+    pub(crate) fn has_closing_quote_before_tag_boundary(
+        &mut self,
+        closing_kind: SyntaxKind,
+    ) -> bool {
+        self.source
+            .has_closing_quote_before_tag_boundary(closing_kind)
+    }
+
     /// Efficiently checks if the parser is at a `{% keyword` sequence
     /// (including whitespace control variants `{%-` and `{%~`).
     pub(crate) fn at_twig_tag(&mut self, keyword: SyntaxKind) -> bool {

--- a/crates/ludtwig-parser/src/parser/source.rs
+++ b/crates/ludtwig-parser/src/parser/source.rs
@@ -72,6 +72,33 @@ impl<'source> Source<'source> {
         }
     }
 
+    /// Scans ahead from the token AFTER the current position to check whether
+    /// `closing_kind` appears before any HTML tag-boundary token or EOF.
+    pub(super) fn has_closing_quote_before_tag_boundary(
+        &mut self,
+        closing_kind: SyntaxKind,
+    ) -> bool {
+        self.eat_trivia();
+        let mut pos = self.cursor + 1;
+        while pos < self.tokens.len() {
+            let kind = self.tokens[pos].kind;
+            if kind == closing_kind {
+                return true;
+            }
+            if matches!(
+                kind,
+                SyntaxKind::TK_LESS_THAN
+                    | SyntaxKind::TK_LESS_THAN_SLASH
+                    | SyntaxKind::TK_LESS_THAN_EXCLAMATION_MARK
+                    | SyntaxKind::TK_LESS_THAN_EXCLAMATION_MARK_MINUS_MINUS
+            ) {
+                return false;
+            }
+            pos += 1;
+        }
+        false // EOF reached without finding closing quote
+    }
+
     /// Peeks the kind of the next non-trivia token after the current position.
     /// Assumes `eat_trivia` has already been called (cursor is at a non-trivia token).
     pub(super) fn peek_next_non_trivia_kind(&mut self) -> Option<SyntaxKind> {


### PR DESCRIPTION
My attempt at a fix for #189. Very new to rust in general so happy to revise if anything doesn't meet the project's standards.