### PR TITLE
fix:  incorrectly flagging camelCase SVG attributes

### DIFF
--- a/crates/ludtwig/CHANGELOG.md
+++ b/crates/ludtwig/CHANGELOG.md
@@ -1,5 +1,7 @@
 # NEXT-VERSION
 
+- [#188](https://github.com/MalteJanz/ludtwig/issues/188) ix `html-attribute-name-kebab-case` incorrectly flagging camelCase SVG attributes (e.g. `viewBox`, `preserveAspectRatio`) by skipping the rule inside `<svg>` elements
+
 # v0.13.0
 
 - [#149](https://github.com/MalteJanz/ludtwig/issues/149) Fixed indentation being incorrectly modified inside `<script>`
@@ -22,10 +24,10 @@
 
 - Bumped version of `ludtwig-parser` to `0.9.0`
 - Adjusted docker build and release process:
-    - the image should be available for `linux/amd64` and (new) `linux/arm64` platforms now
-    - the ludtwig executable is now the entrypoint of the image, so you don't need to call ludtwig and can immediately
-      pass parameters
-    - it's still an alpine based image to have compatibility with most CI pipeline environments
+  - the image should be available for `linux/amd64` and (new) `linux/arm64` platforms now
+  - the ludtwig executable is now the entrypoint of the image, so you don't need to call ludtwig and can immediately
+    pass parameters
+  - it's still an alpine based image to have compatibility with most CI pipeline environments
 
 # v0.11.0
 
@@ -167,4 +169,3 @@
   Improved readability for parsing errors by displaying the error and its context in a way that is readable by the user.
   For example missing closing tags will give the context with each attribute to identify the right tag.
   The attributes were not displayed in a user readable way before this change.
-  

--- a/crates/ludtwig/CHANGELOG.md
+++ b/crates/ludtwig/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NEXT-VERSION
 
-- [#188](https://github.com/MalteJanz/ludtwig/issues/188) ix `html-attribute-name-kebab-case` incorrectly flagging camelCase SVG attributes (e.g. `viewBox`, `preserveAspectRatio`) by skipping the rule inside `<svg>` elements
+- [#188](https://github.com/MalteJanz/ludtwig/issues/188) fix `html-attribute-name-kebab-case` incorrectly flagging camelCase SVG attributes (e.g. `viewBox`, `preserveAspectRatio`) by skipping the rule inside `<svg>` elements
 
 # v0.13.0
 

--- a/crates/ludtwig/src/check/rules/html_attribute_name_kebab_case.rs
+++ b/crates/ludtwig/src/check/rules/html_attribute_name_kebab_case.rs
@@ -1,6 +1,6 @@
 use crate::check::naming_convention::{is_valid_alphanumeric_kebab_case, try_make_kebab_case};
 use crate::check::rule::{CheckResult, Rule, RuleExt, RuleRunContext, Severity};
-use ludtwig_parser::syntax::typed::{AstNode, HtmlAttribute};
+use ludtwig_parser::syntax::typed::{AstNode, HtmlAttribute, HtmlTag};
 use ludtwig_parser::syntax::untyped::SyntaxNode;
 
 pub struct RuleHtmlAttributeNameKebabCase;
@@ -16,6 +16,10 @@ impl Rule for RuleHtmlAttributeNameKebabCase {
 
         if attribute.html_tag()?.is_twig_component() {
             return None; // skip this rule for twig components, because they often use camelCase as params
+        }
+
+        if is_inside_svg(attribute.syntax()) {
+            return None; // skip this rule inside SVG elements, which use camelCase attribute names
         }
 
         if !is_valid_alphanumeric_kebab_case(attribute_name.text()) {
@@ -43,6 +47,16 @@ impl Rule for RuleHtmlAttributeNameKebabCase {
         }
         None
     }
+}
+
+/// Returns true when `node` is contained within an `<svg>` element.
+fn is_inside_svg(node: &SyntaxNode) -> bool {
+    node.ancestors()
+        .filter_map(HtmlTag::cast)
+        .any(|tag| {
+            tag.name()
+                .is_some_and(|name| name.text().eq_ignore_ascii_case("svg"))
+        })
 }
 
 #[cfg(test)]
@@ -76,6 +90,43 @@ mod tests {
             "html-attribute-name-kebab-case",
             r#"<twig:namespaced:component :myCamelCaseAttribute="asdf"/>"#,
             expect![[r#"<twig:namespaced:component :myCamelCaseAttribute="asdf"/>"#]],
+        );
+    }
+
+    #[test]
+    fn rule_does_not_report_svg_viewbox() {
+        test_rule_does_not_fix(
+            "html-attribute-name-kebab-case",
+            r#"<svg viewBox="0 0 100 100"></svg>"#,
+            expect![[r#"<svg viewBox="0 0 100 100"></svg>"#]],
+        );
+    }
+
+    #[test]
+    fn rule_does_not_report_svg_child_camel_case() {
+        test_rule_does_not_fix(
+            "html-attribute-name-kebab-case",
+            r#"<svg><image preserveAspectRatio="none"/></svg>"#,
+            expect![[r#"<svg><image preserveAspectRatio="none"/></svg>"#]],
+        );
+    }
+
+    #[test]
+    fn rule_reports_camel_case_outside_svg() {
+        test_rule(
+            "html-attribute-name-kebab-case",
+            r#"<div viewBox="whatever"/>"#,
+            expect![[r#"
+                help[html-attribute-name-kebab-case]: Attribute name is not written in kebab-case
+                  ┌─ ./debug-rule.html.twig:1:6
+                  │
+                1 │ <div viewBox="whatever"/>
+                  │      ^^^^^^^
+                  │      │
+                  │      help: rename this attribute in kebab-case
+                  │      Try this name instead: view-box
+
+            "#]],
         );
     }
 


### PR DESCRIPTION
fix #188 by skipping the `html-attribute-name-kebab-case` rule for `<svg>` tags. 

This is implemented for SVG only and not for any embedded XML but it should cover 99% of use cases.